### PR TITLE
🗃️ Curator: preserve scaling attributes from stripping by as.matrix in NN modeling scripts

### DIFF
--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -7,6 +7,8 @@ output: html_document
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)
+# Source data integrity utilities
+source(here::here("R", "utils_integrity.R"))
 ################
 ##Load Libraries
 ################
@@ -552,7 +554,7 @@ LM_variable_importance <- function(test, lm_model,
 ELN_variable_importance <- function(test, eln_model, alpha, lambda,
                                     macro_factor_names, individual_factor_names) {
   all_factor_names <- c(macro_factor_names, individual_factor_names)[-1]
-  test_x <- as.matrix(test[4:ncol(test)])
+  test_x <- as_matrix_preserve(test[4:ncol(test)])
   
   variable_importance_df <- foreach(i = (1:(length(all_factor_names))), .combine = "rbind",
                                     .packages = "hqreg") %dopar% {
@@ -611,9 +613,9 @@ NNet_variable_importance <- function(test, nnet_model,
     zero_indices <- which(str_detect(colnames(test_x_zero), all_factor_names[i]) == 1)
     test_x_zero[, zero_indices] <- 0
 
-    original_R2 <- R2(predict(nnet_model, as.matrix(test_x)), test$rt, form = "traditional")
+    original_R2 <- R2(predict(nnet_model, as_matrix_preserve(test_x)), test$rt, form = "traditional")
 
-    new_R2 <- R2(predict(nnet_model, as.matrix(test_x_zero)), test$rt, form = "traditional")
+    new_R2 <- R2(predict(nnet_model, as_matrix_preserve(test_x_zero)), test$rt, form = "traditional")
 
     variable_importance <- data.frame(variable = all_factor_names[i], importance = (original_R2 - new_R2))
 
@@ -658,7 +660,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
     test_cross_section <- test %>%
       filter(time == time_periods[t])
 
-    test_cross_section_x <- as.matrix(test_cross_section[4:ncol(test_cross_section)])
+    test_cross_section_x <- as_matrix_preserve(test_cross_section[4:ncol(test_cross_section)])
     
     residuals <- test_cross_section$rt - predict(eln_model, test_cross_section_x,
                                                  alpha = alpha, lambda = lambda)
@@ -701,7 +703,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
     
     test_cross_section_x <- test_cross_section[4:ncol(test_cross_section)]
     
-    residuals <- test_cross_section$rt - (nnet_model %>% predict(as.matrix(test_cross_section_x)))
+    residuals <- test_cross_section$rt - (nnet_model %>% predict(as_matrix_preserve(test_cross_section_x)))
     
     mean(residuals)
   }
@@ -836,12 +838,12 @@ ELN_fit_stats <- function(alpha_grid, nlamb, timeSlices, pooled_panel, loss_func
     test <- pooled_panel %>%
       filter(time %in% timeSlices[[set]]$test)
     
-    train_x <- as.matrix(train[4:ncol(train)])
-    train_y <- as.matrix(train$rt)
-    validation_x <- as.matrix(validation[4:ncol(validation)])
-    validation_y <- as.matrix(validation$rt)
-    test_x <- as.matrix(test[4:ncol(test)])
-    test_y <- as.matrix(test$rt)
+    train_x <- as_matrix_preserve(train[4:ncol(train)])
+    train_y <- as_matrix_preserve(train$rt)
+    validation_x <- as_matrix_preserve(validation[4:ncol(validation)])
+    validation_y <- as_matrix_preserve(validation$rt)
+    test_x <- as_matrix_preserve(test[4:ncol(test)])
+    test_y <- as_matrix_preserve(test$rt)
       
     #Get models fit over the grid of hyperparameters
     ELN_model_grid <- ELN_model_grid(alpha_grid, train_x, train_y, validation_x, validation_y, loss_function, nlamb = nlamb)
@@ -1282,16 +1284,16 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     # Namely, batch size
     # In general, larger batch sizes result in faster progress in training, but don't always converge as fast. Smaller batch sizes train slower, but can converge faster.
     # Default batch size is 32
-    neural_network %>% fit(as.matrix(train_x), as.matrix(train_y), 
+    neural_network %>% fit(as_matrix_preserve(train_x), as_matrix_preserve(train_y),
                            batch_size = batch_size, epochs = 500, verbose = 1, 
-                           validation_data = list(as.matrix(validation_x), as.matrix(validation_y)),
+                           validation_data = list(as_matrix_preserve(validation_x), as_matrix_preserve(validation_y)),
                            callbacks = list(early_stop, print_dot_callback))
     
     # Model
     # NNet_stats[[set]]$model <- neural_network
     
     #Train
-    train_predict <- neural_network %>% predict(as.matrix(train_x))
+    train_predict <- neural_network %>% predict(as_matrix_preserve(train_x))
     
     NNet_stats[[set]]$loss_stats$train_MAE <- mae(train$rt, train_predict)
     NNet_stats[[set]]$loss_stats$train_MSE <- mse(train$rt, train_predict)
@@ -1299,7 +1301,7 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     NNet_stats[[set]]$loss_stats$train_RSquare <- R2(train_predict, train$rt, form = "traditional")
           
     #Validation
-    validation_predict <- neural_network %>% predict(as.matrix(validation_x))
+    validation_predict <- neural_network %>% predict(as_matrix_preserve(validation_x))
     
     NNet_stats[[set]]$loss_stats$validation_MAE <- mae(validation$rt, validation_predict)
     NNet_stats[[set]]$loss_stats$validation_MSE <- mse(validation$rt, validation_predict)
@@ -1307,7 +1309,7 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     NNet_stats[[set]]$loss_stats$validation_RSquare <- R2(validation_predict, validation$rt, form = "traditional")
       
     #Test
-    test_predict <- neural_network %>% predict(as.matrix(test_x))
+    test_predict <- neural_network %>% predict(as_matrix_preserve(test_x))
     
     NNet_stats[[set]]$loss_stats$test_MAE <- mae(test$rt, test_predict)
     NNet_stats[[set]]$loss_stats$test_MSE <- mse(test$rt, test_predict)

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -49,6 +49,9 @@ library(doFuture)
 ```
 
 ```{r train_valid_test}
+# Source data integrity utilities
+source(here::here("R", "utils_integrity.R"))
+
 #Create Training + Test Sets
 
 # Gu et al set a training, validation and test sample equal in length for their simulations. Not the most sensible idea
@@ -138,7 +141,7 @@ LM_variable_importance <- function(test, lm_model) {
 # Penalized Linear Model
 
 ELN_variable_importance <- function(test, eln_model, alpha, lambda) {
-  test_x <- as.matrix(test[4:ncol(test)])
+  test_x <- as_matrix_preserve(test[4:ncol(test)])
   
   variable_importance_df <- foreach(i = (1:ncol(test_x)), .combine = "rbind") %dopar% {
     test_x_zero <- test_x
@@ -186,9 +189,9 @@ NNet_variable_importance <- function(test, nnet_model) {
     test_x_zero <- test_x
     test_x_zero[, i] <- 0
 
-    original_R2 <- R2(predict(nnet_model, as.matrix(test_x)), test$rt, form = "traditional")
+    original_R2 <- R2(predict(nnet_model, as_matrix_preserve(test_x)), test$rt, form = "traditional")
 
-    new_R2 <- R2(predict(nnet_model, as.matrix(test_x_zero)), test$rt, form = "traditional")
+    new_R2 <- R2(predict(nnet_model, as_matrix_preserve(test_x_zero)), test$rt, form = "traditional")
 
     variable_importance <- data.frame(variable = colnames(test_x)[i], importance = (original_R2 - new_R2))
 
@@ -235,7 +238,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
     test_cross_section <- test %>%
       filter(time == time_periods[t])
 
-    test_cross_section_x <- as.matrix(test_cross_section[4:ncol(test_cross_section)])
+    test_cross_section_x <- as_matrix_preserve(test_cross_section[4:ncol(test_cross_section)])
     
     residuals <- test_cross_section$rt - predict(eln_model, test_cross_section_x,
                                                  alpha = alpha, lambda = lambda)
@@ -278,7 +281,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
     
     test_cross_section_x <- test_cross_section[4:ncol(test_cross_section)]
     
-    residuals <- test_cross_section$rt - (nnet_model %>% predict(as.matrix(test_cross_section_x)))
+    residuals <- test_cross_section$rt - (nnet_model %>% predict(as_matrix_preserve(test_cross_section_x)))
     
     mean(residuals)
   }
@@ -475,12 +478,12 @@ ELN_fit_stats <- function(ELN_grid, nlambda, timeSlices, pooled_panel, loss_func
     test <- pooled_panel %>%
       filter(time %in% timeSlices[[set]]$test)
     
-    train_x <- as.matrix(train[4:ncol(train)])
-    train_y <- as.matrix(train$rt)
-    validation_x <- as.matrix(validation[4:ncol(validation)])
-    validation_y <- as.matrix(validation$rt)
-    test_x <- as.matrix(test[4:ncol(test)])
-    test_y <- as.matrix(test$rt)
+    train_x <- as_matrix_preserve(train[4:ncol(train)])
+    train_y <- as_matrix_preserve(train$rt)
+    validation_x <- as_matrix_preserve(validation[4:ncol(validation)])
+    validation_y <- as_matrix_preserve(validation$rt)
+    test_x <- as_matrix_preserve(test[4:ncol(test)])
+    test_y <- as_matrix_preserve(test$rt)
       
     #Get models fit over the grid of hyperparameters
     ELN_model_grid <- ELN_model_grid(ELN_grid, train_x, train_y, validation_x, validation_y, loss_function, nlambda = nlambda)
@@ -1155,16 +1158,16 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     # Namely, batch size
     # In general, larger batch sizes result in faster progress in training, but don't always converge as fast. Smaller batch sizes train slower, but can converge faster.
     # Default batch size is 32
-    neural_network %>% fit(as.matrix(train_x), as.matrix(train_y), 
+    neural_network %>% fit(as_matrix_preserve(train_x), as_matrix_preserve(train_y),
                            batch_size = batch_size, epochs = 500, verbose = 0, 
-                           validation_data = list(as.matrix(validation_x), as.matrix(validation_y)),
+                           validation_data = list(as_matrix_preserve(validation_x), as_matrix_preserve(validation_y)),
                            callbacks = list(early_stop, print_dot_callback))
     
     #Model
     #NNet_stats[[set]]$model <- neural_network
     
     #Train
-    train_predict <- neural_network %>% predict(as.matrix(train_x))
+    train_predict <- neural_network %>% predict(as_matrix_preserve(train_x))
     
     NNet_stats[[set]]$loss_stats$train_MAE <- mae(train$rt, train_predict)
     NNet_stats[[set]]$loss_stats$train_MSE <- mse(train$rt, train_predict)
@@ -1172,7 +1175,7 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     NNet_stats[[set]]$loss_stats$train_RSquare <- R2(train_predict, train$rt, form = "traditional")
           
     #Validation
-    validation_predict <- neural_network %>% predict(as.matrix(validation_x))
+    validation_predict <- neural_network %>% predict(as_matrix_preserve(validation_x))
     
     NNet_stats[[set]]$loss_stats$validation_MAE <- mae(validation$rt, validation_predict)
     NNet_stats[[set]]$loss_stats$validation_MSE <- mse(validation$rt, validation_predict)
@@ -1180,7 +1183,7 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     NNet_stats[[set]]$loss_stats$validation_RSquare <- R2(validation_predict, validation$rt, form = "traditional")
       
     #Test
-    test_predict <- neural_network %>% predict(as.matrix(test_x))
+    test_predict <- neural_network %>% predict(as_matrix_preserve(test_x))
     
     NNet_stats[[set]]$loss_stats$test_MAE <- mae(test$rt, test_predict)
     NNet_stats[[set]]$loss_stats$test_MSE <- mse(test$rt, test_predict)

--- a/R/utils_integrity.R
+++ b/R/utils_integrity.R
@@ -1,0 +1,37 @@
+#' Safely convert objects to matrix while preserving critical attributes
+#'
+#' @param x An object to convert to matrix (e.g., ts, mts, zoo, xts, data.frame)
+#' @param ... Additional arguments passed to base::as.matrix
+#' @return A matrix with original attributes restored
+as_matrix_preserve <- function(x, ...) {
+  if (is.null(x)) {
+    stop("Input cannot be NULL")
+  }
+
+  # Preserve original attributes
+  orig_attrs <- attributes(x)
+
+  # Extract numeric matrix based on class
+  if (inherits(x, c("zoo", "xts"))) {
+    if (!requireNamespace("zoo", quietly = TRUE)) {
+      stop("Package 'zoo' is required for zoo/xts objects.")
+    }
+    res <- zoo::coredata(x)
+  } else {
+    res <- base::as.matrix(x, ...)
+  }
+
+  # Restore attributes that don't conflict with basic matrix structure
+  # We preserve scaling attributes, transformation metadata, and custom properties
+  if (!is.null(orig_attrs)) {
+    attrs_to_keep <- orig_attrs[setdiff(names(orig_attrs), c("dim", "dimnames", "class", "index", "tsp", "names", "row.names"))]
+
+    if (length(attrs_to_keep) > 0) {
+      for (attr_name in names(attrs_to_keep)) {
+        attr(res, attr_name) <- attrs_to_keep[[attr_name]]
+      }
+    }
+  }
+
+  return(res)
+}


### PR DESCRIPTION
🚨 **Issue:** `as.matrix()` conversions for Neural Network inputs and other modelling frameworks stripped crucial scaling and structural metadata attributes like `scaled:center` and `scaled:scale`.
💡 **Fix:** Implemented `R/utils_integrity.R` providing `as_matrix_preserve()` that leverages `coredata` (for `xts`/`zoo` objects) while copying non-structural attributes to the matrix representation without mutating length mismatch regressions. Replaced `as.matrix(train_x)` and corresponding instances across `Real Data.Rmd` and `Simulation Models.Rmd` to correctly preserve attributes for inputs, predictions and residual pipelines.
🧪 **Verification:** Ensured class integrity manually inside R, verifying that the scaled metadata matches array requirements locally. Code reviewed to correctly extract structures. No core test suites exist for `devtools::test()` in the root directory.

---
*PR created automatically by Jules for task [2148523871098547007](https://jules.google.com/task/2148523871098547007) started by @zeyuz35*