### PR TITLE
📝 Docent: format predict_first_ntree.R

### DIFF
--- a/R/xgboost/demo/predict_first_ntree.R
+++ b/R/xgboost/demo/predict_first_ntree.R
@@ -1,23 +1,35 @@
+# Setup ------------------------------------------------------------------------
 require(xgboost)
-# load in the agaricus dataset
-data(agaricus.train, package='xgboost')
-data(agaricus.test, package='xgboost')
+
+# Load in the agaricus dataset.
+data(agaricus.train, package = "xgboost")
+data(agaricus.test, package = "xgboost")
+
 dtrain <- xgb.DMatrix(agaricus.train$data, label = agaricus.train$label)
 dtest <- xgb.DMatrix(agaricus.test$data, label = agaricus.test$label)
 
-param <- list(max_depth=2, eta=1, silent=1, objective='binary:logistic')
+param <- list(
+  max_depth = 2,
+  eta = 1,
+  objective = "binary:logistic",
+  nthread = 2
+)
 watchlist <- list(eval = dtest, train = dtrain)
-nrounds = 2
+nrounds <- 2
 
-# training the model for two rounds
-bst = xgb.train(param, dtrain, nrounds, nthread = 2, watchlist)
-cat('start testing prediction from first n trees\n')
-labels <- getinfo(dtest,'label')
+# Training ---------------------------------------------------------------------
+# Train the model for two rounds.
+bst <- xgb.train(param, dtrain, nrounds, watchlist)
+message("start testing prediction from first n trees")
+labels <- getinfo(dtest, "label")
 
-### predict using first 1 tree
-ypred1 = predict(bst, dtest, ntreelimit=1)
-# by default, we predict using all the trees
-ypred2 = predict(bst, dtest)
+# Prediction -------------------------------------------------------------------
+# Predict using first 1 tree.
+ypred1 <- predict(bst, dtest, iterationrange = c(1, 2))
 
-cat('error of ypred1=', mean(as.numeric(ypred1>0.5)!=labels),'\n')
-cat('error of ypred2=', mean(as.numeric(ypred2>0.5)!=labels),'\n')
+# By default, we predict using all the trees.
+ypred2 <- predict(bst, dtest)
+
+# Results ----------------------------------------------------------------------
+message("error of ypred1=", mean(as.numeric(ypred1 > 0.5) != labels))
+message("error of ypred2=", mean(as.numeric(ypred2 > 0.5) != labels))


### PR DESCRIPTION
💡 **What:** Modernized comments, output messages, and code style in `R/xgboost/demo/predict_first_ntree.R`.
🎯 **Why:** To align with `agents.md` documentation and style constraints (using `message()` instead of `cat()`, adding foldable headers, ensuring ASCII-only communication, and proper R style). Fixed an XGBoost deprecation warning along the way (`ntreelimit` -> `iterationrange`).
📊 **Scope:** `R/xgboost/demo/predict_first_ntree.R` (< 50 lines changed).
✅ **Verification:** `styler::style_file` reports clean formatting. Executed `Rscript R/xgboost/demo/predict_first_ntree.R` locally with no runtime regressions or warnings.

---
*PR created automatically by Jules for task [9478895754067904991](https://jules.google.com/task/9478895754067904991) started by @zeyuz35*