### PR TITLE
⚙️ Modernizer: replace magrittr pipes with native pipes in sagemaker demo

### DIFF
--- a/R/AWS/sagemaker_demo.R
+++ b/R/AWS/sagemaker_demo.R
@@ -21,24 +21,24 @@ ggplot(abalone, aes(x = height, y = rings, color = sex)) + geom_point() + geom_j
 
 ## Cleaning
 
-abalone <- abalone %>%
+abalone <- abalone |>
   filter(height != 0)
 
-abalone <- abalone %>%
+abalone <- abalone |>
   mutate(female = as.integer(ifelse(sex == 'F', 1, 0)),
          male = as.integer(ifelse(sex == 'M', 1, 0)),
-         infant = as.integer(ifelse(sex == 'I', 1, 0))) %>%
+         infant = as.integer(ifelse(sex == 'I', 1, 0))) |>
   select(-sex)
-abalone <- abalone %>%
+abalone <- abalone |>
   select(rings:infant, length:shell_weight)
 head(abalone)
 
 ## Train/test split
 
-abalone_train <- abalone %>%
+abalone_train <- abalone |>
   sample_frac(size = 0.7)
 abalone <- anti_join(abalone, abalone_train)
-abalone_test <- abalone %>%
+abalone_test <- abalone |>
   sample_frac(size = 0.5)
 abalone_valid <- anti_join(abalone, abalone_test)
 


### PR DESCRIPTION
## 💡 What
Replace 6 instances of the magrittr pipe `%>%` with the native base R pipe `|>` in `R/AWS/sagemaker_demo.R`.

## 🎯 Why
Native base R pipes reduce the dependency burden on the `magrittr` or `dplyr` packages, enabling cleaner and more contemporary R syntax. The operations here do not rely on specialized magrittr behavior (like the `.` placeholder), making them perfectly suited for the native pipe.

## 📊 Impact
Improved maintainability and slightly faster execution due to less overhead from external package bindings.

## ✅ Verification
The refactored snippet corresponding to data cleaning and splitting was manually extracted and verified against the `abalone` dataset. The script ran correctly, generating the expected dataset without any regressions in logic. Additionally, the standalone script was removed post-verification to avoid cluttering the repository.

---
*PR created automatically by Jules for task [2327861617847342034](https://jules.google.com/task/2327861617847342034) started by @zeyuz35*