### PR TITLE
📦 Binder: update path abstraction and namespace usage in umap_play

### DIFF
--- a/R/umap_play.R
+++ b/R/umap_play.R
@@ -8,9 +8,9 @@ library(Rtsne)
 library(tsfeatures)
 library(gganimate) # required for printing tours
 library(sneezy)
-final_dataset <- readRDS("~/Dropbox/website/Evaluation-of-Machine-Learning-in-Asset-Pricing/R/final_dataset.rds")
+final_dataset <- readRDS(here::here("R", "final_dataset.rds"))
 
-final_dataset_t<-final_dataset%>%select(-rt)
+final_dataset_t <- final_dataset |> dplyr::select(-rt)
 
 row_sample<- sample(2:18048,3000, replace=F)
 col_sample<- sample(1:740,500, replace=F)


### PR DESCRIPTION
💡 **What**:
- Replaced the `magrittr` pipe (`%>%`) with the native R pipe (`|>`).
- Added an explicit `dplyr::` namespace to the `select` function call.
- Replaced a hardcoded absolute file path (`~/Dropbox/...`) with the `here::here()` abstraction.

🎯 **Why**:
- Using the native pipe removes the implicit requirement for the `magrittr` or `dplyr` packages to provide the pipe operator, moving towards base R.
- Explicitly namespacing `dplyr::select` avoids reliance on `dplyr` being globally attached via `library()`, preventing potential namespace collisions.
- Hardcoded absolute paths break reproducibility; `here::here()` ensures the script can run seamlessly on any machine referencing the project root.

📊 **Impact**:
- 1 file modified (`R/umap_play.R`).
- Improves portability and clarifies namespace usage.

✅ **Verification**:
- R script syntax successfully verified via `base::parse()`.

---
*PR created automatically by Jules for task [12123752832187235929](https://jules.google.com/task/12123752832187235929) started by @zeyuz35*