### PR TITLE
⚙️ Modernizer: Update pipes and iterators in aws_prep.Rmd

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,1 +1,1 @@
-## Modernizer Journal
+## Modernizer Journal\n

--- a/R/aws_prep.Rmd
+++ b/R/aws_prep.Rmd
@@ -58,7 +58,7 @@ toJSON(json_test)
 ```{r}
 ## 
 tidy_to_json <- function(data) {
-  stock_id <- data$stock %>%
+  stock_id <- data$stock |>
     unique()
   
   # Number of cross sectional units
@@ -69,20 +69,20 @@ tidy_to_json <- function(data) {
                                   target = c(1:cross_units), 
                                   dynamic_feat = c(1:cross_units))
   
-  for (i in 1:cross_units) {
-    pooled_panel_filter <- data %>%
-      filter(stock == stock_id[i])
+  for (ii in 1:cross_units) {
+    pooled_panel_filter <- data |>
+      filter(stock == stock_id[ii])
     
-    pooled_panel_json$target[i] <- list(pooled_panel_filter$rt)
+    pooled_panel_json$target[ii] <- list(pooled_panel_filter$rt)
     
-    pooled_panel_filter_feature <- pooled_panel_filter %>%
-      select(-time, -rt, -stock) %>%
-      unname() %>%
-      as.matrix() %>%
+    pooled_panel_filter_feature <- pooled_panel_filter |>
+      select(-time, -rt, -stock) |>
+      unname() |>
+      as.matrix() |>
       # Transpose it to get the right format of one feature series per row
       t()
     
-    pooled_panel_json[i, ]$dynamic_feat <- pooled_panel_filter_feature %>% list()
+    pooled_panel_json[ii, ]$dynamic_feat <- pooled_panel_filter_feature |> list()
   }
   
   pooled_panel_json
@@ -98,7 +98,7 @@ tidy_to_json <- function(data) {
 ## Below is some dummy data, and shows us the format we need for it to work with AWS inference
 
 test <- fromJSON("inference_test.json")
-test %>% toJSON
+test |> toJSON()
 
 # Ie we want a list of 2:
 # instances
@@ -111,7 +111,7 @@ test %>% toJSON
   # quantiles
 
 
-pooled_panel_json <- pooled_panel %>% tidy_to_json()
+pooled_panel_json <- pooled_panel |> tidy_to_json()
 
 inference_json <- list(
   instances = list(start = pooled_panel_json$start, 


### PR DESCRIPTION
**What**: Refactored `tidy_to_json` in `R/aws_prep.Rmd` to use the native pipe operator (`|>`) instead of the magrittr pipe (`%>%`). Changed the single-character iterator `i` to `ii`.

**Why**: This improves code maintainability and complies with contemporary R standards (native pipes reduce dependencies, double-character iterators improve searchability and clarity).

**Impact**: Improved readability and reduced reliance on external packages for piping logic. Found out that the right hand side requires parentheses `f()` for `|>`.

**Verification**: Verified via `rmarkdown::render()` compilation. No syntax errors were detected, and behavior remains structurally identical.

---
*PR created automatically by Jules for task [8397170928209664204](https://jules.google.com/task/8397170928209664204) started by @zeyuz35*