### PR TITLE
⚙️ Modernizer: Use tcrossprod instead of %*% t() in Sim_david.Rmd

### DIFF
--- a/R/simulation/Sim_david.Rmd
+++ b/R/simulation/Sim_david.Rmd
@@ -95,7 +95,8 @@ gen_W <- function(){
   
   #Use Lambda to create B matrix
   
-  B <- (Lambda) %*% t(Lambda)
+  # Equivalent: tcrossprod(Lambda) is Lambda %*% t(Lambda) but faster
+  B <- tcrossprod(Lambda)
   B <- B + 1/10*diag(nrow = nrow(B))
   
   #Turn B into a correlation matrix


### PR DESCRIPTION
💡 What: Replaced `Lambda %*% t(Lambda)` with `tcrossprod(Lambda)` in `R/simulation/Sim_david.Rmd`.
🎯 Why: Utilizing `tcrossprod()` relies on underlying optimized C code rather than explicitly computing the transpose and matrix multiplication, improving execution speed while preserving accuracy.
📊 Impact: Performance improvement by skipping explicit matrix transposition.
✅ Verification: Successfully parsed and syntax-checked with `knitr::purl()` and `parse()`. Functionality mathematically proven identical in the local bash session.

---
*PR created automatically by Jules for task [8391392554534155368](https://jules.google.com/task/8391392554534155368) started by @zeyuz35*