### PR TITLE
🗃️ Curator: Preserve attributes on coercion to matrix

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,5 @@
+## 2024-05-30 - Preserving attributes on as.matrix() coercion
+
+**Learning:** Base R's `as.matrix()` inherently drops critical non-structural attributes such as indices (`index`, `tsp`) and scaling parameters (`scaled:center`, `scaled:scale`). When converting time-series objects to computationally safe matrices (dropping the class so method dispatch is generic), we must manually save and re-attach these attributes so downstream code (e.g. backtransformation) does not fail silently.
+
+**Action:** Created `as_matrix_preserve()` which safely captures non-structural attributes, calls `as.matrix()`, and reinstates attributes while omitting the `class` attribute. Applied this function to `.R` scripts like `R/AWS/sagemaker_run.R` where matrices are extracted from time series structures for deep learning contexts but still need their metadata attached.

--- a/R/AWS/sagemaker_run.R
+++ b/R/AWS/sagemaker_run.R
@@ -63,6 +63,7 @@
 ########################################################################################################
 
 library("reticulate")
+source(here::here("R", "utils_integrity.R"))
 ## Force reticulate to use the right version of anaconda and thus sagemaker modules
 use_condaenv("/home/ubuntu/anaconda3", required = TRUE)
 sagemaker <- import('sagemaker')
@@ -145,7 +146,7 @@ tidy_to_json <- function(data, start) {
     pooled_panel_filter_feature <- pooled_panel_filter %>%
       select(-time, -rt, -stock) %>%
       unname() %>%
-      as.matrix() %>%
+      as_matrix_preserve() %>%
       # Transpose it to get the right format of one feature series per row
       t()
     
@@ -366,7 +367,7 @@ tidy_to_batch_inf <- function(data, start, timeSlices, set) {
       filter(time %in% timeSlices[[set]]$train | time %in% timeSlices[[set]]$validation | time %in% timeSlices[[set]]$test) %>%
       dplyr::select(-time, -rt, -stock) %>%
       unname() %>%
-      as.matrix() %>%
+      as_matrix_preserve() %>%
       # Transpose it to get the right format of one feature series per row
       t()
     

--- a/R/generics.R
+++ b/R/generics.R
@@ -1,0 +1,2 @@
+# Source utilities that contain as_matrix_preserve
+source(here::here("R", "utils_integrity.R"))

--- a/R/utils_integrity.R
+++ b/R/utils_integrity.R
@@ -1,0 +1,19 @@
+#' Coerce to matrix while preserving time-series classes and attributes
+#'
+#' @param x An object to coerce to matrix
+#' @return A matrix that retains the original attributes but drops class to be computationally safe
+as_matrix_preserve <- function(x) {
+  # Capture original attributes
+  orig_attrs <- attributes(x)
+
+  # Coerce to matrix
+  res <- as.matrix(x)
+
+  # Restore attributes except those structural to matrices and class
+  non_structural <- setdiff(names(orig_attrs), c("dim", "dimnames", "class"))
+  for (attr_name in non_structural) {
+    attr(res, attr_name) <- orig_attrs[[attr_name]]
+  }
+
+  res
+}

--- a/tests/testthat/test-utils_integrity.R
+++ b/tests/testthat/test-utils_integrity.R
@@ -1,0 +1,54 @@
+library(testthat)
+source("../../R/utils_integrity.R")
+
+test_that("as_matrix_preserve preserves attributes but drops class for xts", {
+  library(xts)
+  x <- xts(matrix(1:10, ncol=2), order.by=Sys.Date() + 1:5)
+  attr(x, "scaled:center") <- c(0, 0)
+  attr(x, "scaled:scale") <- c(1, 1)
+
+  y <- as_matrix_preserve(x)
+
+  expect_false(inherits(y, "xts"))
+  expect_true(is.matrix(y))
+  expect_equal(attr(y, "scaled:center"), c(0, 0))
+  expect_equal(attr(y, "scaled:scale"), c(1, 1))
+  expect_equal(attr(y, "index"), attr(x, "index"))
+})
+
+test_that("as_matrix_preserve preserves attributes but drops class for ts", {
+  x <- ts(1:10, frequency=4, start=c(1959, 2))
+  attr(x, "scaled:center") <- 0
+  attr(x, "scaled:scale") <- 1
+
+  y <- as_matrix_preserve(x)
+
+  expect_false(inherits(y, "ts"))
+  expect_true(is.matrix(y))
+  expect_equal(attr(y, "scaled:center"), 0)
+  expect_equal(attr(y, "scaled:scale"), 1)
+  expect_equal(attr(y, "tsp"), attr(x, "tsp"))
+})
+
+test_that("as_matrix_preserve preserves attributes but drops class for zoo", {
+  library(zoo)
+  x <- zoo(matrix(1:10, ncol=2), order.by=1:5)
+  attr(x, "scaled:center") <- c(0, 0)
+
+  y <- as_matrix_preserve(x)
+
+  expect_false(inherits(y, "zoo"))
+  expect_true(is.matrix(y))
+  expect_equal(attr(y, "scaled:center"), c(0, 0))
+  expect_equal(attr(y, "index"), attr(x, "index"))
+})
+
+test_that("as_matrix_preserve preserves generic attributes on numeric matrices", {
+  x <- matrix(1:10, ncol=2)
+  attr(x, "custom_attr") <- "test"
+
+  y <- as_matrix_preserve(x)
+
+  expect_equal(attr(y, "custom_attr"), "test")
+  expect_true(is.matrix(y))
+})


### PR DESCRIPTION
🚨 Issue: Base R `as.matrix()` silently drops critical non-structural attributes such as transformation and scaling metadata when extracting core numerical data from time series objects.
💡 Fix: Added a custom utility `as_matrix_preserve()` to `R/utils_integrity.R` that safely coerces time-series to arrays/matrices while explicitly restoring non-structural attributes but dropping the class to maintain safe generic dispatch. Updated `R/AWS/sagemaker_run.R` to utilize this.
🧪 Tests: Added test cases under `tests/testthat/` covering `ts`, `xts`, `zoo`, and numeric class coercions.
✅ Verification: Tested against standard assertions confirming attribute preservation and generic object construction.

---
*PR created automatically by Jules for task [12904060598702533086](https://jules.google.com/task/12904060598702533086) started by @zeyuz35*