### PR TITLE
📝 Docent: [replace cat with message]

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Replacing cat() with message() without newlines
+**Learning:** `message()` automatically appends newlines, so when replacing `cat(".")` to print dots on a single line for progress indicators, we cannot simply use `message(".")` because it will print each dot on a new line. We can use `message(".", appendLF = FALSE)`.
+**Action:** Always use `appendLF = FALSE` when replicating the behavior of `cat()` for progress dots using `message()`.

--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -1116,8 +1116,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     


### PR DESCRIPTION
💡 What: Replaced `cat()` outputs to console for progress tracking in neural net training with `message()` functions in `R/empirical/Real Data.Rmd`.
🎯 Why: `agents.md` specifies that `cat()` calls shouldn't be left in production code and must be converted to `message()`/`warning()`. Added `.jules/docent.md` journal entry detailing this change as `message` adds newlines automatically and needs `appendLF=FALSE` to replicate the `cat(".")` behaviour.
📊 Scope: Modified 2 lines in `R/empirical/Real Data.Rmd`.
✅ Verification: Parsed the resulting `temp.R` output using `knitr::purl`. Code compiles. No new WARNINGs/NOTEs about documentation. Clean air format on target modified lines.

---
*PR created automatically by Jules for task [4275155359516610410](https://jules.google.com/task/4275155359516610410) started by @zeyuz35*