### PR TITLE
📦 Binder: Move exploratory script out of R/ and remove unused dependencies

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## Binder Journal
+
+This journal tracks non-routine critical learnings related to package hygiene, namespaces, dependencies, file organization, and `R CMD check` warnings or errors.

--- a/analysis/umap_play.R
+++ b/analysis/umap_play.R
@@ -1,13 +1,7 @@
 library(umap)
-library(purrr)
-library(tidyr)
 library(dplyr)
 library(ggplot2)
 library(Rtsne)
-#devtools::install_github("robjhyndman/tsfeatures")
-library(tsfeatures)
-library(gganimate) # required for printing tours
-library(sneezy)
 final_dataset <- readRDS("~/Dropbox/website/Evaluation-of-Machine-Learning-in-Asset-Pricing/R/final_dataset.rds")
 
 final_dataset_t<-final_dataset%>%select(-rt)


### PR DESCRIPTION
💡 **What:** Moved `umap_play.R` out of the `R/` directory into `analysis/` and removed unused `library()` calls (`purrr`, `tidyr`, `tsfeatures`, `gganimate`, `sneezy`).
🎯 **Why:** `umap_play.R` is an exploratory data analysis script. Having files with top-level `library()` calls or hardcoded local paths inside the `R/` directory violates CRAN package standards, as `R/` is reserved exclusively for package function definitions. Additionally, removing unused imports minimizes the script's dependency footprint.
📊 **Impact:** Reorganized 1 file (`R/umap_play.R` -> `analysis/umap_play.R`) and removed 5 unused dependency imports. This ensures `R CMD build` or `R CMD check` won't incorrectly process this exploratory file as package code in the future.
✅ **Verification:** Verified code syntax with `parse()`, ensuring the file remains valid after removing the dependencies. Created `.jules/binder.md` for journal logs.

---
*PR created automatically by Jules for task [16089477540519891502](https://jules.google.com/task/16089477540519891502) started by @zeyuz35*