### PR TITLE
⚙️ Modernizer: [pattern update]

### DIFF
--- a/R/AWS/sagemaker_run.R
+++ b/R/AWS/sagemaker_run.R
@@ -125,7 +125,7 @@ library(jsonlite)
 ## that is ready to be exported to JSON for use with sagemaker deepar
 
 tidy_to_json <- function(data, start) {
-  stock_id <- data$stock %>%
+  stock_id <- data$stock |>
     unique()
   
   # Number of cross sectional units
@@ -136,20 +136,20 @@ tidy_to_json <- function(data, start) {
                                   target = c(1:cross_units), 
                                   dynamic_feat = c(1:cross_units))
   
-  for (i in 1:cross_units) {
-    pooled_panel_filter <- data %>%
-      filter(stock == stock_id[i])
+  for (ii in 1:cross_units) {
+    pooled_panel_filter <- data |>
+      filter(stock == stock_id[ii])
     
-    pooled_panel_json$target[i] <- list(pooled_panel_filter$rt)
+    pooled_panel_json$target[ii] <- list(pooled_panel_filter$rt)
     
-    pooled_panel_filter_feature <- pooled_panel_filter %>%
-      select(-time, -rt, -stock) %>%
-      unname() %>%
-      as.matrix() %>%
+    pooled_panel_filter_feature <- pooled_panel_filter |>
+      select(-time, -rt, -stock) |>
+      unname() |>
+      as.matrix() |>
       # Transpose it to get the right format of one feature series per row
       t()
     
-    pooled_panel_json[i, ]$dynamic_feat <- pooled_panel_filter_feature %>% list()
+    pooled_panel_json[ii, ]$dynamic_feat <- pooled_panel_filter_feature |> list()
   }
   pooled_panel_json
 }


### PR DESCRIPTION
💡 What: Replaced magrittr pipes (`%>%`) with native pipes (`|>`) and renamed single-letter loop iterator `i` to `ii` in `tidy_to_json()` within `R/AWS/sagemaker_run.R`.
🎯 Why: Native pipes reduce dependency on magrittr and double-letter iterators improve code readability and searchability.
📊 Impact: Improves maintainability and adheres to modern R standards while keeping changes localized and under 50 lines.
✅ Verification: Tested R script parsing using `parse('R/AWS/sagemaker_run.R')` successfully. No functional changes introduced.

---
*PR created automatically by Jules for task [8545082443628730042](https://jules.google.com/task/8545082443628730042) started by @zeyuz35*