### PR TITLE
📝 Docent: Replace cat() with message() in scripts

### DIFF
--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -1116,8 +1116,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/empirical_robustness/ff_factors/Real Data.Rmd
+++ b/R/empirical_robustness/ff_factors/Real Data.Rmd
@@ -1167,8 +1167,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/empirical_robustness/missing_threshold/Real Data.Rmd
+++ b/R/empirical_robustness/missing_threshold/Real Data.Rmd
@@ -1117,8 +1117,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/empirical_robustness/train_valid_1/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_1/Real Data.Rmd
@@ -1112,8 +1112,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/empirical_robustness/train_valid_2/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_2/Real Data.Rmd
@@ -1119,8 +1119,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -989,8 +989,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     
@@ -1438,8 +1438,8 @@ LSTM_fit_stats <- function(pooled_panel, timeSlices, loss_function, batch_size, 
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/xgboost/demo/create_sparse_matrix.R
+++ b/R/xgboost/demo/create_sparse_matrix.R
@@ -2,47 +2,47 @@ require(xgboost)
 require(Matrix)
 require(data.table)
 if (!require(vcd)) {
-  install.packages('vcd') #Available in Cran. Used for its dataset with categorical values.
+  install.packages("vcd") # Available in Cran. Used for its dataset with categorical values.
   require(vcd)
 }
 # According to its documentation, Xgboost works only on numbers.
-# Sometimes the dataset we have to work on have categorical data. 
+# Sometimes the dataset we have to work on have categorical data.
 # A categorical variable is one which have a fixed number of values. By example, if for each observation a variable called "Colour" can have only "red", "blue" or "green" as value, it is a categorical variable.
 #
-# In R, categorical variable is called Factor. 
+# In R, categorical variable is called Factor.
 # Type ?factor in console for more information.
 #
 # In this demo we will see how to transform a dense dataframe with categorical variables to a sparse matrix before analyzing it in Xgboost.
 # The method we are going to see is usually called "one hot encoding".
 
-#load Arthritis dataset in memory.
+# load Arthritis dataset in memory.
 data(Arthritis)
 
 # create a copy of the dataset with data.table package (data.table is 100% compliant with R dataframe but its syntax is a lot more consistent and its performance are really good).
 df <- data.table(Arthritis, keep.rownames = F)
 
 # Let's have a look to the data.table
-cat("Print the dataset\n")
+message("Print the dataset")
 print(df)
 
 # 2 columns have factor type, one has ordinal type (ordinal variable is a categorical variable with values wich can be ordered, here: None > Some > Marked).
-cat("Structure of the dataset\n")
+message("Structure of the dataset")
 str(df)
 
 # Let's add some new categorical features to see if it helps. Of course these feature are highly correlated to the Age feature. Usually it's not a good thing in ML, but Tree algorithms (including boosted trees) are able to select the best features, even in case of highly correlated features.
 
 # For the first feature we create groups of age by rounding the real age. Note that we transform it to factor (categorical data) so the algorithm treat them as independant values.
-df[,AgeDiscret:= as.factor(round(Age/10,0))]
+df[, AgeDiscret := as.factor(round(Age / 10, 0))]
 
 # Here is an even stronger simplification of the real age with an arbitrary split at 30 years old. I choose this value based on nothing. We will see later if simplifying the information based on arbitrary values is a good strategy (I am sure you already have an idea of how well it will work!).
-df[,AgeCat:= as.factor(ifelse(Age > 30, "Old", "Young"))]
+df[, AgeCat := as.factor(ifelse(Age > 30, "Old", "Young"))]
 
 # We remove ID as there is nothing to learn from this feature (it will just add some noise as the dataset is small).
-df[,ID:=NULL]
+df[, ID := NULL]
 
 # List the different values for the column Treatment: Placebo, Treated.
-cat("Values of the categorical feature Treatment\n")
-print(levels(df[,Treatment]))
+message("Values of the categorical feature Treatment")
+print(levels(df[, Treatment]))
 
 # Next step, we will transform the categorical data to dummy variables.
 # This method is also called one hot encoding.
@@ -52,21 +52,23 @@ print(levels(df[,Treatment]))
 #
 # Formulae Improved~.-1 used below means transform all categorical features but column Improved to binary values.
 # Column Improved is excluded because it will be our output column, the one we want to predict.
-sparse_matrix = sparse.model.matrix(Improved~.-1, data = df)
+sparse_matrix <- sparse.model.matrix(Improved ~ . - 1, data = df)
 
-cat("Encoding of the sparse Matrix\n")
+message("Encoding of the sparse Matrix")
 print(sparse_matrix)
 
 # Create the output vector (not sparse)
-# 1. Set, for all rows, field in Y column to 0; 
-# 2. set Y to 1 when Improved == Marked; 
+# 1. Set, for all rows, field in Y column to 0;
+# 2. set Y to 1 when Improved == Marked;
 # 3. Return Y column
-output_vector = df[,Y:=0][Improved == "Marked",Y:=1][,Y]
+output_vector <- df[, Y := 0][Improved == "Marked", Y := 1][, Y]
 
 # Following is the same process as other demo
-cat("Learning...\n")
-bst <- xgboost(data = sparse_matrix, label = output_vector, max_depth = 9,
-               eta = 1, nthread = 2, nrounds = 10, objective = "binary:logistic")
+message("Learning...")
+bst <- xgboost(
+  data = sparse_matrix, label = output_vector, max_depth = 9,
+  eta = 1, nthread = 2, nrounds = 10, objective = "binary:logistic"
+)
 
 importance <- xgb.importance(feature_names = colnames(sparse_matrix), model = bst)
 print(importance)

--- a/R/xgboost/demo/cross_validation.R
+++ b/R/xgboost/demo/cross_validation.R
@@ -1,47 +1,53 @@
 require(xgboost)
 # load in the agaricus dataset
-data(agaricus.train, package='xgboost')
-data(agaricus.test, package='xgboost')
+data(agaricus.train, package = "xgboost")
+data(agaricus.test, package = "xgboost")
 dtrain <- xgb.DMatrix(agaricus.train$data, label = agaricus.train$label)
 dtest <- xgb.DMatrix(agaricus.test$data, label = agaricus.test$label)
 
 nrounds <- 2
-param <- list(max_depth=2, eta=1, silent=1, nthread=2, objective='binary:logistic')
+param <- list(max_depth = 2, eta = 1, silent = 1, nthread = 2, objective = "binary:logistic")
 
-cat('running cross validation\n')
+message("running cross validation")
 # do cross validation, this will print result out as
 # [iteration]  metric_name:mean_value+std_value
 # std_value is standard deviation of the metric
-xgb.cv(param, dtrain, nrounds, nfold=5, metrics={'error'})
+xgb.cv(param, dtrain, nrounds, nfold = 5, metrics = {
+  "error"
+})
 
-cat('running cross validation, disable standard deviation display\n')
+message("running cross validation, disable standard deviation display")
 # do cross validation, this will print result out as
 # [iteration]  metric_name:mean_value+std_value
 # std_value is standard deviation of the metric
-xgb.cv(param, dtrain, nrounds, nfold=5,
-       metrics='error', showsd = FALSE)
+xgb.cv(param, dtrain, nrounds,
+  nfold = 5,
+  metrics = "error", showsd = FALSE
+)
 
 ###
 # you can also do cross validation with cutomized loss function
 # See custom_objective.R
 ##
-print ('running cross validation, with cutomsized loss function')
+print("running cross validation, with cutomsized loss function")
 
 logregobj <- function(preds, dtrain) {
   labels <- getinfo(dtrain, "label")
-  preds <- 1/(1 + exp(-preds))
+  preds <- 1 / (1 + exp(-preds))
   grad <- preds - labels
   hess <- preds * (1 - preds)
   return(list(grad = grad, hess = hess))
 }
 evalerror <- function(preds, dtrain) {
   labels <- getinfo(dtrain, "label")
-  err <- as.numeric(sum(labels != (preds > 0)))/length(labels)
+  err <- as.numeric(sum(labels != (preds > 0))) / length(labels)
   return(list(metric = "error", value = err))
 }
 
-param <- list(max_depth=2, eta=1, silent=1,
-              objective = logregobj, eval_metric = evalerror)
+param <- list(
+  max_depth = 2, eta = 1, silent = 1,
+  objective = logregobj, eval_metric = evalerror
+)
 # train with customized objective
 xgb.cv(params = param, data = dtrain, nrounds = nrounds, nfold = 5)
 

--- a/R/xgboost/demo/generalized_linear_model.R
+++ b/R/xgboost/demo/generalized_linear_model.R
@@ -1,7 +1,7 @@
 require(xgboost)
 # load in the agaricus dataset
-data(agaricus.train, package='xgboost')
-data(agaricus.test, package='xgboost')
+data(agaricus.train, package = "xgboost")
+data(agaricus.test, package = "xgboost")
 dtrain <- xgb.DMatrix(agaricus.train$data, label = agaricus.train$label)
 dtest <- xgb.DMatrix(agaricus.test$data, label = agaricus.test$label)
 ##
@@ -11,14 +11,16 @@ dtest <- xgb.DMatrix(agaricus.test$data, label = agaricus.test$label)
 ##
 
 # change booster to gblinear, so that we are fitting a linear model
-# alpha is the L1 regularizer 
+# alpha is the L1 regularizer
 # lambda is the L2 regularizer
 # you can also set lambda_bias which is L2 regularizer on the bias term
-param <- list(objective = "binary:logistic", booster = "gblinear",
-              nthread = 2, alpha = 0.0001, lambda = 1)
+param <- list(
+  objective = "binary:logistic", booster = "gblinear",
+  nthread = 2, alpha = 0.0001, lambda = 1
+)
 
 # normally, you do not need to set eta (step_size)
-# XGBoost uses a parallel coordinate descent algorithm (shotgun), 
+# XGBoost uses a parallel coordinate descent algorithm (shotgun),
 # there could be affection on convergence with parallelization on certain cases
 # setting eta to be smaller value, e.g 0.5 can make the optimization more stable
 
@@ -29,6 +31,5 @@ watchlist <- list(eval = dtest, train = dtrain)
 num_round <- 2
 bst <- xgb.train(param, dtrain, num_round, watchlist)
 ypred <- predict(bst, dtest)
-labels <- getinfo(dtest, 'label')
-cat('error of preds=', mean(as.numeric(ypred>0.5)!=labels),'\n')
-
+labels <- getinfo(dtest, "label")
+message("error of preds=", mean(as.numeric(ypred > 0.5) != labels))

--- a/R/xgboost/demo/predict_first_ntree.R
+++ b/R/xgboost/demo/predict_first_ntree.R
@@ -1,23 +1,23 @@
 require(xgboost)
 # load in the agaricus dataset
-data(agaricus.train, package='xgboost')
-data(agaricus.test, package='xgboost')
+data(agaricus.train, package = "xgboost")
+data(agaricus.test, package = "xgboost")
 dtrain <- xgb.DMatrix(agaricus.train$data, label = agaricus.train$label)
 dtest <- xgb.DMatrix(agaricus.test$data, label = agaricus.test$label)
 
-param <- list(max_depth=2, eta=1, silent=1, objective='binary:logistic')
+param <- list(max_depth = 2, eta = 1, silent = 1, objective = "binary:logistic")
 watchlist <- list(eval = dtest, train = dtrain)
-nrounds = 2
+nrounds <- 2
 
 # training the model for two rounds
-bst = xgb.train(param, dtrain, nrounds, nthread = 2, watchlist)
-cat('start testing prediction from first n trees\n')
-labels <- getinfo(dtest,'label')
+bst <- xgb.train(param, dtrain, nrounds, nthread = 2, watchlist)
+message("start testing prediction from first n trees")
+labels <- getinfo(dtest, "label")
 
 ### predict using first 1 tree
-ypred1 = predict(bst, dtest, ntreelimit=1)
+ypred1 <- predict(bst, dtest, ntreelimit = 1)
 # by default, we predict using all the trees
-ypred2 = predict(bst, dtest)
+ypred2 <- predict(bst, dtest)
 
-cat('error of ypred1=', mean(as.numeric(ypred1>0.5)!=labels),'\n')
-cat('error of ypred2=', mean(as.numeric(ypred2>0.5)!=labels),'\n')
+message("error of ypred1=", mean(as.numeric(ypred1 > 0.5) != labels))
+message("error of ypred2=", mean(as.numeric(ypred2 > 0.5) != labels))

--- a/R/xgboost/demo/predict_leaf_indices.R
+++ b/R/xgboost/demo/predict_leaf_indices.R
@@ -5,34 +5,34 @@ require(Matrix)
 set.seed(1982)
 
 # load in the agaricus dataset
-data(agaricus.train, package='xgboost')
-data(agaricus.test, package='xgboost')
+data(agaricus.train, package = "xgboost")
+data(agaricus.test, package = "xgboost")
 dtrain <- xgb.DMatrix(data = agaricus.train$data, label = agaricus.train$label)
 dtest <- xgb.DMatrix(data = agaricus.test$data, label = agaricus.test$label)
 
-param <- list(max_depth=2, eta=1, silent=1, objective='binary:logistic')
-nrounds = 4
+param <- list(max_depth = 2, eta = 1, silent = 1, objective = "binary:logistic")
+nrounds <- 4
 
 # training the model for two rounds
-bst = xgb.train(params = param, data = dtrain, nrounds = nrounds, nthread = 2)
+bst <- xgb.train(params = param, data = dtrain, nrounds = nrounds, nthread = 2)
 
 # Model accuracy without new features
 accuracy.before <- sum((predict(bst, agaricus.test$data) >= 0.5) == agaricus.test$label) / length(agaricus.test$label)
 
 # by default, we predict using all the trees
 
-pred_with_leaf = predict(bst, dtest, predleaf = TRUE)
+pred_with_leaf <- predict(bst, dtest, predleaf = TRUE)
 head(pred_with_leaf)
 
-create.new.tree.features <- function(model, original.features){
+create.new.tree.features <- function(model, original.features) {
   pred_with_leaf <- predict(model, original.features, predleaf = TRUE)
   cols <- list()
-  for(i in 1:model$niter){
+  for (i in 1:model$niter) {
     # max is not the real max but it s not important for the purpose of adding features
-    leaf.id <- sort(unique(pred_with_leaf[,i]))
-    cols[[i]] <- factor(x = pred_with_leaf[,i], level = leaf.id)
+    leaf.id <- sort(unique(pred_with_leaf[, i]))
+    cols[[i]] <- factor(x = pred_with_leaf[, i], level = leaf.id)
   }
-  cbind(original.features, sparse.model.matrix( ~ . -1, as.data.frame(cols)))
+  cbind(original.features, sparse.model.matrix(~ . - 1, as.data.frame(cols)))
 }
 
 # Convert previous features to one hot encoding
@@ -50,4 +50,4 @@ bst <- xgb.train(params = param, data = new.dtrain, nrounds = nrounds, nthread =
 accuracy.after <- sum((predict(bst, new.dtest) >= 0.5) == agaricus.test$label) / length(agaricus.test$label)
 
 # Here the accuracy was already good and is now perfect.
-cat(paste("The accuracy was", accuracy.before, "before adding leaf features and it is now", accuracy.after, "!\n"))
+message(paste("The accuracy was", accuracy.before, "before adding leaf features and it is now", accuracy.after, "!"))


### PR DESCRIPTION
💡 What: Replaced `cat()` statements used for output logging and progress monitoring with `message()` in xgboost demo scripts and empirical Rmd files.

🎯 Why: To comply with style guidelines indicating that `cat()` shouldn't be used for standard output. The `message()` function correctly logs standard messages with automatic newline formatting. `appendLF = FALSE` was used for dot progress logs to replicate exact behavior. 

📊 Scope: 
- `R/xgboost/demo/create_sparse_matrix.R`
- `R/xgboost/demo/predict_first_ntree.R`
- `R/xgboost/demo/generalized_linear_model.R`
- `R/xgboost/demo/cross_validation.R`
- `R/xgboost/demo/predict_leaf_indices.R`
- `R/empirical/Real Data.Rmd`
- `R/empirical_robustness/train_valid_1/Real Data.Rmd`
- `R/empirical_robustness/train_valid_2/Real Data.Rmd`
- `R/empirical_robustness/ff_factors/Real Data.Rmd`
- `R/empirical_robustness/missing_threshold/Real Data.Rmd`
- `R/simulation/Simulation Models.Rmd`

✅ Verification: Validated R code syntax using `parse()` directly for R files and via `knitr::purl()` for `.Rmd` files. Applied targeted code styling using `styler::style_file()` instead of full repository formatters.

---
*PR created automatically by Jules for task [1452294208522897734](https://jules.google.com/task/1452294208522897734) started by @zeyuz35*