### PR TITLE
📦 Binder: [improvement] Move umap_play.R out of R/ and remove unused dependencies

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,5 @@
+## 2024-03-22 - Missing R Package Structure
+
+**Learning:** This repository is primarily a data analysis project and currently lacks a formal R package structure (e.g., DESCRIPTION, NAMESPACE, R/ directory with only function definitions). Standard package building/checking tools like `R CMD check` will not work.
+
+**Action:** Will focus on script-level hygiene improvements, such as replacing magrittr pipes or removing library calls where appropriate within the constraints of an analysis project.

--- a/analysis/umap_play.R
+++ b/analysis/umap_play.R
@@ -1,16 +1,10 @@
 library(umap)
-library(purrr)
-library(tidyr)
-library(dplyr)
 library(ggplot2)
 library(Rtsne)
-#devtools::install_github("robjhyndman/tsfeatures")
-library(tsfeatures)
-library(gganimate) # required for printing tours
-library(sneezy)
+
 final_dataset <- readRDS("~/Dropbox/website/Evaluation-of-Machine-Learning-in-Asset-Pricing/R/final_dataset.rds")
 
-final_dataset_t<-final_dataset%>%select(-rt)
+final_dataset_t <- subset(final_dataset, select = -rt)
 
 row_sample<- sample(2:18048,3000, replace=F)
 col_sample<- sample(1:740,500, replace=F)
@@ -29,7 +23,7 @@ ggplot(d_umap_1, aes(x=V1, y=V2)) +
   guides(colour=guide_legend(override.aes=list(size=6)))
 
 
-tsne <- Rtsne(data.temp, dims = 2, perplexity=35, verbose=TRUE, max_iter = 2000)
+tsne <- Rtsne(unique(data.temp), dims = 2, perplexity=35, verbose=TRUE, max_iter = 2000)
 
 
 ## Plotting


### PR DESCRIPTION
💡 **What:**
- Moved `umap_play.R` from the `R/` directory to the `analysis/` directory.
- Removed unused library dependencies (`purrr`, `tidyr`, `tsfeatures`, `gganimate`, `sneezy`).
- Replaced the `dplyr` pipe `final_dataset %>% select(-rt)` with base R's `subset(final_dataset, select = -rt)`.
- Added a `unique()` wrapper to `data.temp` when calling `Rtsne` to prevent execution errors.

🎯 **Why:**
- By R package standards, the `R/` directory must only contain function definitions. Exploratory scripts should reside elsewhere (e.g., `analysis/`).
- Removing unused libraries and converting the `dplyr` pipe to base R (`subset`) reduces external dependencies.
- `Rtsne()` throws a fatal error if given data with duplicate rows.

📊 **Impact:**
- `umap_play.R` relocated to `analysis/`.
- 6 library imports removed.

✅ **Verification:**
- Syntactic verification of the modified file using `Rscript -e "parse('analysis/umap_play.R')"`.

---
*PR created automatically by Jules for task [14486521490743694075](https://jules.google.com/task/14486521490743694075) started by @zeyuz35*