### PR TITLE
⚙️ Modernizer: [native pipe update] umap_play.R

### DIFF
--- a/R/umap_play.R
+++ b/R/umap_play.R
@@ -10,7 +10,7 @@ library(gganimate) # required for printing tours
 library(sneezy)
 final_dataset <- readRDS("~/Dropbox/website/Evaluation-of-Machine-Learning-in-Asset-Pricing/R/final_dataset.rds")
 
-final_dataset_t<-final_dataset%>%select(-rt)
+final_dataset_t <- final_dataset |> select(-rt)
 
 row_sample<- sample(2:18048,3000, replace=F)
 col_sample<- sample(1:740,500, replace=F)


### PR DESCRIPTION
💡 What: Replaced magrittr pipe `%>%` with native R pipe `|>` in `R/umap_play.R` for the `final_dataset_t` assignment.
🎯 Why: Removes reliance on the external `magrittr` dependency and uses base R's native pipe convention for improved long-term maintainability.
📊 Impact: Minor readability gain and follows base R standards. No change in functionality since `select(-rt)` works seamlessly as the right-hand-side function call.
✅ Verification: Successfully ran `Rscript -e "parse('R/umap_play.R')"` to ensure valid syntax. Code logic remains completely identical.

---
*PR created automatically by Jules for task [14433388468301280772](https://jules.google.com/task/14433388468301280772) started by @zeyuz35*