### PR TITLE
📝 Docent: [style fix] replace cat() with message() in xgboost demos

### DIFF
--- a/R/xgboost/demo/cross_validation.R
+++ b/R/xgboost/demo/cross_validation.R
@@ -8,13 +8,13 @@ dtest <- xgb.DMatrix(agaricus.test$data, label = agaricus.test$label)
 nrounds <- 2
 param <- list(max_depth=2, eta=1, silent=1, nthread=2, objective='binary:logistic')
 
-cat('running cross validation\n')
+message('running cross validation')
 # do cross validation, this will print result out as
 # [iteration]  metric_name:mean_value+std_value
 # std_value is standard deviation of the metric
 xgb.cv(param, dtrain, nrounds, nfold=5, metrics={'error'})
 
-cat('running cross validation, disable standard deviation display\n')
+message('running cross validation, disable standard deviation display')
 # do cross validation, this will print result out as
 # [iteration]  metric_name:mean_value+std_value
 # std_value is standard deviation of the metric
@@ -25,7 +25,7 @@ xgb.cv(param, dtrain, nrounds, nfold=5,
 # you can also do cross validation with cutomized loss function
 # See custom_objective.R
 ##
-print ('running cross validation, with cutomsized loss function')
+message('running cross validation, with cutomsized loss function')
 
 logregobj <- function(preds, dtrain) {
   labels <- getinfo(dtrain, "label")

--- a/R/xgboost/demo/generalized_linear_model.R
+++ b/R/xgboost/demo/generalized_linear_model.R
@@ -30,5 +30,5 @@ num_round <- 2
 bst <- xgb.train(param, dtrain, num_round, watchlist)
 ypred <- predict(bst, dtest)
 labels <- getinfo(dtest, 'label')
-cat('error of preds=', mean(as.numeric(ypred>0.5)!=labels),'\n')
+message('error of preds=', mean(as.numeric(ypred>0.5)!=labels))
 


### PR DESCRIPTION
💡 What: Replaced `cat()` and `print()` calls with `message()` in two xgboost demo scripts (`cross_validation.R` and `generalized_linear_model.R`) and removed explicit trailing newlines.
🎯 Why: Adherence to `agents.md` rule: "Replace `cat()` calls used for progress reporting or informational messages with `base::message()`" and "Remove explicit newline characters (`\n`) when converting to `message()` or `warning()`, as these functions append newlines automatically".
📊 Scope: Modified `R/xgboost/demo/cross_validation.R` and `R/xgboost/demo/generalized_linear_model.R` (< 50 lines).
✅ Verification: Scripts syntax checked with `parse()`.

---
*PR created automatically by Jules for task [3281540565556930857](https://jules.google.com/task/3281540565556930857) started by @zeyuz35*