### PR TITLE
📝 Docent: [style] Replace cat with message in predict_first_ntree demo

### DIFF
--- a/R/xgboost/demo/predict_first_ntree.R
+++ b/R/xgboost/demo/predict_first_ntree.R
@@ -1,23 +1,23 @@
 require(xgboost)
 # load in the agaricus dataset
-data(agaricus.train, package='xgboost')
-data(agaricus.test, package='xgboost')
+data(agaricus.train, package = "xgboost")
+data(agaricus.test, package = "xgboost")
 dtrain <- xgb.DMatrix(agaricus.train$data, label = agaricus.train$label)
 dtest <- xgb.DMatrix(agaricus.test$data, label = agaricus.test$label)
 
-param <- list(max_depth=2, eta=1, silent=1, objective='binary:logistic')
+param <- list(max_depth = 2, eta = 1, silent = 1, objective = "binary:logistic")
 watchlist <- list(eval = dtest, train = dtrain)
-nrounds = 2
+nrounds <- 2
 
 # training the model for two rounds
-bst = xgb.train(param, dtrain, nrounds, nthread = 2, watchlist)
-cat('start testing prediction from first n trees\n')
-labels <- getinfo(dtest,'label')
+bst <- xgb.train(param, dtrain, nrounds, nthread = 2, watchlist)
+message("start testing prediction from first n trees")
+labels <- getinfo(dtest, "label")
 
 ### predict using first 1 tree
-ypred1 = predict(bst, dtest, ntreelimit=1)
+ypred1 <- predict(bst, dtest, iterationrange = c(1, 2))
 # by default, we predict using all the trees
-ypred2 = predict(bst, dtest)
+ypred2 <- predict(bst, dtest)
 
-cat('error of ypred1=', mean(as.numeric(ypred1>0.5)!=labels),'\n')
-cat('error of ypred2=', mean(as.numeric(ypred2>0.5)!=labels),'\n')
+message(paste0("error of ypred1=", mean(as.numeric(ypred1 > 0.5) != labels)))
+message(paste0("error of ypred2=", mean(as.numeric(ypred2 > 0.5) != labels)))


### PR DESCRIPTION
💡 What: Replaced `cat()` statements with `message()` in `R/xgboost/demo/predict_first_ntree.R`, avoiding manual `\n`. Updated deprecated `ntreelimit` parameter to `iterationrange` which was causing script failures. Formatted file to standard 80-char width constraint.

🎯 Why: To adhere to strict R docent code style guidelines, which prohibit `cat()` calls for progress reporting and informational outputs in favor of standard error streams like `message()`.

📊 Scope: Modified `R/xgboost/demo/predict_first_ntree.R` (15 lines affected/formatted).

✅ Verification: Script `Rscript R/xgboost/demo/predict_first_ntree.R` verified working correctly with no output format issues and regressions.

---
*PR created automatically by Jules for task [5890713132858469534](https://jules.google.com/task/5890713132858469534) started by @zeyuz35*