### PR TITLE
📝 Docent: replace cat with message for progress callbacks

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,5 @@
+## 2024-03-25 - Replace cat with message for progress indicators
+
+**Learning:** When using `cat()` for progress reporting (like printing dots in a loop or callback), it violates the style guideline of not using `cat()` in production code. Converting `cat()` to `message()` requires `appendLF = FALSE` to prevent `message()` from appending a newline after every character, which would break the visual effect of printing progress dots on a single line.
+
+**Action:** Replace `cat(".")` with `message(".", appendLF = FALSE)` and `cat("\\n")` with `message("\\n", appendLF = FALSE)` for inline progress indicators.

--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -1116,8 +1116,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("\n", appendLF = FALSE)
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/empirical_robustness/ff_factors/Real Data.Rmd
+++ b/R/empirical_robustness/ff_factors/Real Data.Rmd
@@ -1167,8 +1167,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("\n", appendLF = FALSE)
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/empirical_robustness/missing_threshold/Real Data.Rmd
+++ b/R/empirical_robustness/missing_threshold/Real Data.Rmd
@@ -1117,8 +1117,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("\n", appendLF = FALSE)
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/empirical_robustness/train_valid_1/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_1/Real Data.Rmd
@@ -1112,8 +1112,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("\n", appendLF = FALSE)
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/empirical_robustness/train_valid_2/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_2/Real Data.Rmd
@@ -1119,8 +1119,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("\n", appendLF = FALSE)
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -989,8 +989,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("\n", appendLF = FALSE)
+        message(".", appendLF = FALSE)
       }
     ) 
     
@@ -1438,8 +1438,8 @@ LSTM_fit_stats <- function(pooled_panel, timeSlices, loss_function, batch_size, 
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("\n", appendLF = FALSE)
+        message(".", appendLF = FALSE)
       }
     ) 
     


### PR DESCRIPTION
💡 **What**: Replaced occurrences of `cat()` used in progress reporting (the `print_dot_callback` function for neural network modeling) with `message()`. Created `.jules/docent.md` to document the learning of using `appendLF = FALSE` with `message()` to replace `cat(".")` when maintaining single-line progress dots.

🎯 **Why**: Using `cat()` in production code bodies is prohibited by the agents.md style guide. The `message()` function should be used instead. By using `message(..., appendLF = FALSE)`, we avoid formatting regressions where each printed dot gets a new line.

📊 **Scope**:
- Modified `R/empirical/Real Data.Rmd` and its related robustness files (`ff_factors`, `missing_threshold`, `train_valid_1`, `train_valid_2`).
- Modified `R/simulation/Simulation Models.Rmd`.
- Created `.jules/docent.md` with the critical learning.
Total lines changed: 12 lines of code modifications, plus the newly created docent journal.

✅ **Verification**:
- R markdown files were parsed with `knitr::purl()` and `parse()` to ensure no syntax errors were introduced.

---
*PR created automatically by Jules for task [3465183548843943371](https://jules.google.com/task/3465183548843943371) started by @zeyuz35*