### PR TITLE
⚙️ Modernizer: Replace magrittr with native pipe

### DIFF
--- a/R/umap_play.R
+++ b/R/umap_play.R
@@ -10,7 +10,7 @@ library(gganimate) # required for printing tours
 library(sneezy)
 final_dataset <- readRDS("~/Dropbox/website/Evaluation-of-Machine-Learning-in-Asset-Pricing/R/final_dataset.rds")
 
-final_dataset_t<-final_dataset%>%select(-rt)
+final_dataset_t<-final_dataset|>select(-rt)
 
 row_sample<- sample(2:18048,3000, replace=F)
 col_sample<- sample(1:740,500, replace=F)


### PR DESCRIPTION
💡 What: Replaced magrittr pipe (`%>%`) with native R pipe (`|>`) in `R/umap_play.R`.
🎯 Why: Reduces reliance on external dependencies (magrittr) and adheres to contemporary R standards.
📊 Impact: Minor readability and dependency improvement.
✅ Verification: Successfully parsed the file without syntax errors using `Rscript -e "parse('R/umap_play.R')"`.

---
*PR created automatically by Jules for task [17636060111353617364](https://jules.google.com/task/17636060111353617364) started by @zeyuz35*