### PR TITLE
📝 Docent: [style fix] Replace cat() with message() in predict_first_ntree.R

### DIFF
--- a/R/xgboost/demo/predict_first_ntree.R
+++ b/R/xgboost/demo/predict_first_ntree.R
@@ -1,23 +1,23 @@
 require(xgboost)
 # load in the agaricus dataset
-data(agaricus.train, package='xgboost')
-data(agaricus.test, package='xgboost')
+data(agaricus.train, package = "xgboost")
+data(agaricus.test, package = "xgboost")
 dtrain <- xgb.DMatrix(agaricus.train$data, label = agaricus.train$label)
 dtest <- xgb.DMatrix(agaricus.test$data, label = agaricus.test$label)
 
-param <- list(max_depth=2, eta=1, silent=1, objective='binary:logistic')
+param <- list(max_depth = 2, eta = 1, silent = 1, objective = "binary:logistic")
 watchlist <- list(eval = dtest, train = dtrain)
-nrounds = 2
+nrounds <- 2
 
 # training the model for two rounds
-bst = xgb.train(param, dtrain, nrounds, nthread = 2, watchlist)
-cat('start testing prediction from first n trees\n')
-labels <- getinfo(dtest,'label')
+bst <- xgb.train(param, dtrain, nrounds, nthread = 2, watchlist)
+message("start testing prediction from first n trees")
+labels <- getinfo(dtest, "label")
 
 ### predict using first 1 tree
-ypred1 = predict(bst, dtest, ntreelimit=1)
+ypred1 <- predict(bst, dtest, ntreelimit = 1)
 # by default, we predict using all the trees
-ypred2 = predict(bst, dtest)
+ypred2 <- predict(bst, dtest)
 
-cat('error of ypred1=', mean(as.numeric(ypred1>0.5)!=labels),'\n')
-cat('error of ypred2=', mean(as.numeric(ypred2>0.5)!=labels),'\n')
+message(paste0("error of ypred1=", mean(as.numeric(ypred1 > 0.5) != labels)))
+message(paste0("error of ypred2=", mean(as.numeric(ypred2 > 0.5) != labels)))


### PR DESCRIPTION
💡 What: Replaced `cat()` print outputs with standard R `message()` calls in `R/xgboost/demo/predict_first_ntree.R` and applied formatting (e.g., `=` to `<-`, spacing out arguments).
🎯 Why: `agents.md` strictly enforces the use of `message()`/`warning()` instead of `cat()` for all informational and progress outputs, and requires `<-` for assignment and proper spacing.
📊 Scope: Modified 1 file (`R/xgboost/demo/predict_first_ntree.R`), changed ~10 lines.
✅ Verification: `Rscript -e "parse('R/xgboost/demo/predict_first_ntree.R')"` executed cleanly without errors, and `styler::style_file()` was successfully run to format the code.

---
*PR created automatically by Jules for task [12668428739389853446](https://jules.google.com/task/12668428739389853446) started by @zeyuz35*