### PR TITLE
📝 Docent: [style fix] Format R/umap_play.R

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,5 @@
+## 2024-05-24 - Formatted R/umap_play.R
+
+**Learning:** Fixed formatting inconsistencies. Use of `styler::style_file` is an effective way to fix style.
+
+**Action:** Continue using `styler` for R scripts formatting when `air` is not available.

--- a/R/umap_play.R
+++ b/R/umap_play.R
@@ -4,47 +4,36 @@ library(tidyr)
 library(dplyr)
 library(ggplot2)
 library(Rtsne)
-#devtools::install_github("robjhyndman/tsfeatures")
+# devtools::install_github("robjhyndman/tsfeatures")
 library(tsfeatures)
 library(gganimate) # required for printing tours
 library(sneezy)
 final_dataset <- readRDS("~/Dropbox/website/Evaluation-of-Machine-Learning-in-Asset-Pricing/R/final_dataset.rds")
 
-final_dataset_t<-final_dataset%>%select(-rt)
+final_dataset_t <- final_dataset %>% select(-rt)
 
-row_sample<- sample(2:18048,3000, replace=F)
-col_sample<- sample(1:740,500, replace=F)
+row_sample <- sample(2:18048, 3000, replace = F)
+col_sample <- sample(1:740, 500, replace = F)
 
-data.temp<- final_dataset[row_sample,]
+data.temp <- final_dataset[row_sample, ]
 
 data.temp[is.na(data.temp)] <- 0
 
-data.umap = umap(data.temp)
+data.umap <- umap(data.temp)
 
 
-d_umap_1 = as.data.frame(data.umap$layout)  
+d_umap_1 <- as.data.frame(data.umap$layout)
 
-ggplot(d_umap_1, aes(x=V1, y=V2)) +  
-  geom_point(size=0.25) +
-  guides(colour=guide_legend(override.aes=list(size=6)))
+ggplot(d_umap_1, aes(x = V1, y = V2)) +
+  geom_point(size = 0.25) +
+  guides(colour = guide_legend(override.aes = list(size = 6)))
 
 
-tsne <- Rtsne(data.temp, dims = 2, perplexity=35, verbose=TRUE, max_iter = 2000)
+tsne <- Rtsne(data.temp, dims = 2, perplexity = 35, verbose = TRUE, max_iter = 2000)
 
 
 ## Plotting
-d_tsne_1 = as.data.frame(tsne$Y)  
-ggplot(d_tsne_1, aes(x=V1, y=V2)) +  
-  geom_point(size=0.25) +
-  guides(colour=guide_legend(override.aes=list(size=6)))
-
-
-
-
-
-
-
-
-
-
-
+d_tsne_1 <- as.data.frame(tsne$Y)
+ggplot(d_tsne_1, aes(x = V1, y = V2)) +
+  geom_point(size = 0.25) +
+  guides(colour = guide_legend(override.aes = list(size = 6)))


### PR DESCRIPTION
💡 **What:** Formatted `R/umap_play.R` to follow standard R code styling conventions using `styler::style_file`.
🎯 **Why:** The code had several style violations: using `=` for assignment instead of `<-`, missing spaces after commas, missing spaces around operators like `%>%`, and multiple empty lines. Standardizing the format improves readability and maintainability.
📊 **Scope:** Changes are strictly stylistic and applied only to `R/umap_play.R`. Total line changes are well below 50.
✅ **Verification:** Verified that changes were under 50 lines using `git diff --stat`. Executed `Rscript -e "parse('R/umap_play.R')"` to ensure the code's syntax remains perfectly valid. Requested and received #Correct# from code review.

---
*PR created automatically by Jules for task [11749723278272552451](https://jules.google.com/task/11749723278272552451) started by @zeyuz35*