### PR TITLE
⚙️ Modernizer: [iterator naming and pipe update]

### DIFF
--- a/R/AWS/sagemaker_run.R
+++ b/R/AWS/sagemaker_run.R
@@ -125,7 +125,7 @@ library(jsonlite)
 ## that is ready to be exported to JSON for use with sagemaker deepar
 
 tidy_to_json <- function(data, start) {
-  stock_id <- data$stock %>%
+  stock_id <- data$stock |>
     unique()
   
   # Number of cross sectional units
@@ -136,20 +136,20 @@ tidy_to_json <- function(data, start) {
                                   target = c(1:cross_units), 
                                   dynamic_feat = c(1:cross_units))
   
-  for (i in 1:cross_units) {
-    pooled_panel_filter <- data %>%
-      filter(stock == stock_id[i])
+  for (cross_unit_ii in 1:cross_units) {
+    pooled_panel_filter <- data |>
+      filter(stock == stock_id[cross_unit_ii])
     
-    pooled_panel_json$target[i] <- list(pooled_panel_filter$rt)
+    pooled_panel_json$target[cross_unit_ii] <- list(pooled_panel_filter$rt)
     
-    pooled_panel_filter_feature <- pooled_panel_filter %>%
-      select(-time, -rt, -stock) %>%
-      unname() %>%
-      as.matrix() %>%
+    pooled_panel_filter_feature <- pooled_panel_filter |>
+      select(-time, -rt, -stock) |>
+      unname() |>
+      as.matrix() |>
       # Transpose it to get the right format of one feature series per row
       t()
     
-    pooled_panel_json[i, ]$dynamic_feat <- pooled_panel_filter_feature %>% list()
+    pooled_panel_json[cross_unit_ii, ]$dynamic_feat <- pooled_panel_filter_feature |> list()
   }
   pooled_panel_json
 }


### PR DESCRIPTION
- **What**: Replaced magrittr pipe (`%>%`) with native pipe (`|>`) and renamed single-letter iterator `i` to `cross_unit_ii` in `tidy_to_json` inside `R/AWS/sagemaker_run.R`.
- **Why**: Native pipes reduce dependency on magrittr package and improve R base usage, descriptive iterator `cross_unit_ii` aids debugging and understanding context compared to standard `i`.
- **Impact**: Readability and maintainability have been improved without compromising any micro-performance.
- **Verification**: Verified using syntax check `Rscript -e "parse('R/AWS/sagemaker_run.R')"`, resulting in zero errors. No existing tests to run but the logic stands identical.

---
*PR created automatically by Jules for task [11914962986094245514](https://jules.google.com/task/11914962986094245514) started by @zeyuz35*