### PR TITLE
📝 Docent: [style fix] Replace cat with message and fix assignments in demo scripts

### DIFF
--- a/R/xgboost/demo/generalized_linear_model.R
+++ b/R/xgboost/demo/generalized_linear_model.R
@@ -1,7 +1,7 @@
 require(xgboost)
 # load in the agaricus dataset
-data(agaricus.train, package='xgboost')
-data(agaricus.test, package='xgboost')
+data(agaricus.train, package = "xgboost")
+data(agaricus.test, package = "xgboost")
 dtrain <- xgb.DMatrix(agaricus.train$data, label = agaricus.train$label)
 dtest <- xgb.DMatrix(agaricus.test$data, label = agaricus.test$label)
 ##
@@ -11,14 +11,16 @@ dtest <- xgb.DMatrix(agaricus.test$data, label = agaricus.test$label)
 ##
 
 # change booster to gblinear, so that we are fitting a linear model
-# alpha is the L1 regularizer 
+# alpha is the L1 regularizer
 # lambda is the L2 regularizer
 # you can also set lambda_bias which is L2 regularizer on the bias term
-param <- list(objective = "binary:logistic", booster = "gblinear",
-              nthread = 2, alpha = 0.0001, lambda = 1)
+param <- list(
+  objective = "binary:logistic", booster = "gblinear",
+  nthread = 2, alpha = 0.0001, lambda = 1
+)
 
 # normally, you do not need to set eta (step_size)
-# XGBoost uses a parallel coordinate descent algorithm (shotgun), 
+# XGBoost uses a parallel coordinate descent algorithm (shotgun),
 # there could be affection on convergence with parallelization on certain cases
 # setting eta to be smaller value, e.g 0.5 can make the optimization more stable
 
@@ -29,6 +31,5 @@ watchlist <- list(eval = dtest, train = dtrain)
 num_round <- 2
 bst <- xgb.train(param, dtrain, num_round, watchlist)
 ypred <- predict(bst, dtest)
-labels <- getinfo(dtest, 'label')
-cat('error of preds=', mean(as.numeric(ypred>0.5)!=labels),'\n')
-
+labels <- getinfo(dtest, "label")
+message(paste0("error of preds=", mean(as.numeric(ypred > 0.5) != labels)))

--- a/R/xgboost/demo/predict_first_ntree.R
+++ b/R/xgboost/demo/predict_first_ntree.R
@@ -1,23 +1,23 @@
 require(xgboost)
 # load in the agaricus dataset
-data(agaricus.train, package='xgboost')
-data(agaricus.test, package='xgboost')
+data(agaricus.train, package = "xgboost")
+data(agaricus.test, package = "xgboost")
 dtrain <- xgb.DMatrix(agaricus.train$data, label = agaricus.train$label)
 dtest <- xgb.DMatrix(agaricus.test$data, label = agaricus.test$label)
 
-param <- list(max_depth=2, eta=1, silent=1, objective='binary:logistic')
+param <- list(max_depth = 2, eta = 1, silent = 1, objective = "binary:logistic")
 watchlist <- list(eval = dtest, train = dtrain)
-nrounds = 2
+nrounds <- 2
 
 # training the model for two rounds
-bst = xgb.train(param, dtrain, nrounds, nthread = 2, watchlist)
-cat('start testing prediction from first n trees\n')
-labels <- getinfo(dtest,'label')
+bst <- xgb.train(param, dtrain, nrounds, nthread = 2, watchlist)
+message("start testing prediction from first n trees")
+labels <- getinfo(dtest, "label")
 
 ### predict using first 1 tree
-ypred1 = predict(bst, dtest, ntreelimit=1)
+ypred1 <- predict(bst, dtest, ntreelimit = 1)
 # by default, we predict using all the trees
-ypred2 = predict(bst, dtest)
+ypred2 <- predict(bst, dtest)
 
-cat('error of ypred1=', mean(as.numeric(ypred1>0.5)!=labels),'\n')
-cat('error of ypred2=', mean(as.numeric(ypred2>0.5)!=labels),'\n')
+message(paste0("error of ypred1=", mean(as.numeric(ypred1 > 0.5) != labels)))
+message(paste0("error of ypred2=", mean(as.numeric(ypred2 > 0.5) != labels)))


### PR DESCRIPTION
💡 What: Replace `cat()` with `message()`/`paste0()`, and convert `=` to `<-` assignments in `predict_first_ntree.R` and `generalized_linear_model.R`.\n🎯 Why: Brings the demo scripts into compliance with explicit `agents.md` Docent standards and R style conventions.\n📊 Scope: `R/xgboost/demo/predict_first_ntree.R` and `R/xgboost/demo/generalized_linear_model.R` (41 lines modified).\n✅ Verification: Syntax verified via `parse()`, line limit checked via `git diff --stat`.

---
*PR created automatically by Jules for task [8799629345733434035](https://jules.google.com/task/8799629345733434035) started by @zeyuz35*