### PR TITLE
📝 Docent: style fix - replace cat with message

### DIFF
--- a/R/xgboost/demo/predict_first_ntree.R
+++ b/R/xgboost/demo/predict_first_ntree.R
@@ -11,7 +11,7 @@ nrounds = 2
 
 # training the model for two rounds
 bst = xgb.train(param, dtrain, nrounds, nthread = 2, watchlist)
-cat('start testing prediction from first n trees\n')
+message('start testing prediction from first n trees')
 labels <- getinfo(dtest,'label')
 
 ### predict using first 1 tree
@@ -19,5 +19,5 @@ ypred1 = predict(bst, dtest, ntreelimit=1)
 # by default, we predict using all the trees
 ypred2 = predict(bst, dtest)
 
-cat('error of ypred1=', mean(as.numeric(ypred1>0.5)!=labels),'\n')
-cat('error of ypred2=', mean(as.numeric(ypred2>0.5)!=labels),'\n')
+message(paste0('error of ypred1=', mean(as.numeric(ypred1>0.5)!=labels)))
+message(paste0('error of ypred2=', mean(as.numeric(ypred2>0.5)!=labels)))


### PR DESCRIPTION
### 💡 What:
Replaced `cat()` calls with `message()` in `R/xgboost/demo/predict_first_ntree.R`, wrapping multiple arguments in `paste0()` and stripping trailing `\n` characters.

### 🎯 Why:
To comply with the Docent style instructions ("Replace `cat()` with `message()`/`warning()` in function bodies").

### 📊 Scope:
Modified `R/xgboost/demo/predict_first_ntree.R`. Changed 3 lines total.

### ✅ Verification:
Ran `Rscript -e "parse('R/xgboost/demo/predict_first_ntree.R')"` with no errors. Ran `pytest` as the formal test check with no regressions. Code review passed.

---
*PR created automatically by Jules for task [11824798915201024418](https://jules.google.com/task/11824798915201024418) started by @zeyuz35*