### PR TITLE
⚙️ Modernizer: Replace magrittr with native pipes in sagemaker_demo.R

### DIFF
--- a/R/AWS/sagemaker_demo.R
+++ b/R/AWS/sagemaker_demo.R
@@ -21,24 +21,24 @@ ggplot(abalone, aes(x = height, y = rings, color = sex)) + geom_point() + geom_j
 
 ## Cleaning
 
-abalone <- abalone %>%
+abalone <- abalone |>
   filter(height != 0)
 
-abalone <- abalone %>%
+abalone <- abalone |>
   mutate(female = as.integer(ifelse(sex == 'F', 1, 0)),
          male = as.integer(ifelse(sex == 'M', 1, 0)),
-         infant = as.integer(ifelse(sex == 'I', 1, 0))) %>%
+         infant = as.integer(ifelse(sex == 'I', 1, 0))) |>
   select(-sex)
-abalone <- abalone %>%
+abalone <- abalone |>
   select(rings:infant, length:shell_weight)
 head(abalone)
 
 ## Train/test split
 
-abalone_train <- abalone %>%
+abalone_train <- abalone |>
   sample_frac(size = 0.7)
 abalone <- anti_join(abalone, abalone_train)
-abalone_test <- abalone %>%
+abalone_test <- abalone |>
   sample_frac(size = 0.5)
 abalone_valid <- anti_join(abalone, abalone_test)
 


### PR DESCRIPTION
💡 **What:** Replaced the magrittr pipe (`%>%`) with the native R pipe (`|>`) in `R/AWS/sagemaker_demo.R`.
🎯 **Why:** To adhere to contemporary R coding standards, using the built-in native pipe functionality introduced in R >= 4.1.0, thereby reducing the implicit reliance on the external `magrittr` package.
📊 **Impact:** Maintains exact functionality with no changes to the algorithm but provides cleaner dependency management and modernization of legacy script syntax.
✅ **Verification:** Ran syntax parser `Rscript -e "parse('R/AWS/sagemaker_demo.R')"` with success, visually confirmed exact 1:1 pipe replacements, and executed the default `pytest` test suite command which completed correctly.

---
*PR created automatically by Jules for task [2202560040625073018](https://jules.google.com/task/2202560040625073018) started by @zeyuz35*