### PR TITLE
📝 Docent: format predict_leaf_indices.R and replace cat with message

### DIFF
--- a/R/xgboost/demo/predict_leaf_indices.R
+++ b/R/xgboost/demo/predict_leaf_indices.R
@@ -5,34 +5,34 @@ require(Matrix)
 set.seed(1982)
 
 # load in the agaricus dataset
-data(agaricus.train, package='xgboost')
-data(agaricus.test, package='xgboost')
+data(agaricus.train, package = "xgboost")
+data(agaricus.test, package = "xgboost")
 dtrain <- xgb.DMatrix(data = agaricus.train$data, label = agaricus.train$label)
 dtest <- xgb.DMatrix(data = agaricus.test$data, label = agaricus.test$label)
 
-param <- list(max_depth=2, eta=1, silent=1, objective='binary:logistic')
-nrounds = 4
+param <- list(max_depth = 2, eta = 1, silent = 1, objective = "binary:logistic")
+nrounds <- 4
 
 # training the model for two rounds
-bst = xgb.train(params = param, data = dtrain, nrounds = nrounds, nthread = 2)
+bst <- xgb.train(params = param, data = dtrain, nrounds = nrounds, nthread = 2)
 
 # Model accuracy without new features
 accuracy.before <- sum((predict(bst, agaricus.test$data) >= 0.5) == agaricus.test$label) / length(agaricus.test$label)
 
 # by default, we predict using all the trees
 
-pred_with_leaf = predict(bst, dtest, predleaf = TRUE)
+pred_with_leaf <- predict(bst, dtest, predleaf = TRUE)
 head(pred_with_leaf)
 
-create.new.tree.features <- function(model, original.features){
+create.new.tree.features <- function(model, original.features) {
   pred_with_leaf <- predict(model, original.features, predleaf = TRUE)
   cols <- list()
-  for(i in 1:model$niter){
+  for (i in 1:model$niter) {
     # max is not the real max but it s not important for the purpose of adding features
-    leaf.id <- sort(unique(pred_with_leaf[,i]))
-    cols[[i]] <- factor(x = pred_with_leaf[,i], level = leaf.id)
+    leaf.id <- sort(unique(pred_with_leaf[, i]))
+    cols[[i]] <- factor(x = pred_with_leaf[, i], level = leaf.id)
   }
-  cbind(original.features, sparse.model.matrix( ~ . -1, as.data.frame(cols)))
+  cbind(original.features, sparse.model.matrix(~ . - 1, as.data.frame(cols)))
 }
 
 # Convert previous features to one hot encoding
@@ -50,4 +50,4 @@ bst <- xgb.train(params = param, data = new.dtrain, nrounds = nrounds, nthread =
 accuracy.after <- sum((predict(bst, new.dtest) >= 0.5) == agaricus.test$label) / length(agaricus.test$label)
 
 # Here the accuracy was already good and is now perfect.
-cat(paste("The accuracy was", accuracy.before, "before adding leaf features and it is now", accuracy.after, "!\n"))
+message(paste("The accuracy was", accuracy.before, "before adding leaf features and it is now", accuracy.after, "!"))


### PR DESCRIPTION
# 📝 Docent: format predict_leaf_indices.R and replace cat with message

## 💡 What
This PR applies formatting guidelines (assignment using `<-` rather than `=`, spacing, standard double quotes) and replaces `cat(paste(..., "!\n"))` with `message(paste(..., "!"))` in `R/xgboost/demo/predict_leaf_indices.R`.

## 🎯 Why
The codebase has a strict rule prohibiting the use of `cat()` for informational output messages. Additionally, the file lacked proper R formatting standards, which the `styler` package addresses.

## 📊 Scope
Modified `R/xgboost/demo/predict_leaf_indices.R`. 
Diff size: +12/-12 lines.

## ✅ Verification
- Syntax verified with `parse()`
- `pytest` collected 0 items as expected
- Diff size verified to be under 50 lines.
- Temporary files deleted.

---
*PR created automatically by Jules for task [5919590686808711377](https://jules.google.com/task/5919590686808711377) started by @zeyuz35*