### PR TITLE
⚙️ Modernizer: Replace magrittr with native pipes in sagemaker_demo.R

### DIFF
--- a/R/AWS/sagemaker_demo.R
+++ b/R/AWS/sagemaker_demo.R
@@ -21,24 +21,24 @@ ggplot(abalone, aes(x = height, y = rings, color = sex)) + geom_point() + geom_j
 
 ## Cleaning
 
-abalone <- abalone %>%
+abalone <- abalone |>
   filter(height != 0)
 
-abalone <- abalone %>%
+abalone <- abalone |>
   mutate(female = as.integer(ifelse(sex == 'F', 1, 0)),
          male = as.integer(ifelse(sex == 'M', 1, 0)),
-         infant = as.integer(ifelse(sex == 'I', 1, 0))) %>%
+         infant = as.integer(ifelse(sex == 'I', 1, 0))) |>
   select(-sex)
-abalone <- abalone %>%
+abalone <- abalone |>
   select(rings:infant, length:shell_weight)
 head(abalone)
 
 ## Train/test split
 
-abalone_train <- abalone %>%
+abalone_train <- abalone |>
   sample_frac(size = 0.7)
 abalone <- anti_join(abalone, abalone_train)
-abalone_test <- abalone %>%
+abalone_test <- abalone |>
   sample_frac(size = 0.5)
 abalone_valid <- anti_join(abalone, abalone_test)
 


### PR DESCRIPTION
## 💡 What

Replaced all instances of the magrittr pipe `%>%` with the native R pipe `|>` in `R/AWS/sagemaker_demo.R`.

## 🎯 Why

To align the codebase with contemporary R standards (R >= 4.1.0) and reduce the implicit dependency on the `magrittr` package for pipe operations, relying on base R instead.

## 📊 Impact

Improves maintainability by using base R constructs without requiring external packages just for piping syntax. Code readability remains identical.

## ✅ Verification

* Syntax successfully validated using `parse('R/AWS/sagemaker_demo.R')` via `Rscript`.
* Visual verification confirms that exact string replacements match native piping requirements (no `. ` usage present).
* Kept within the 50-line limit constraint.

---
*PR created automatically by Jules for task [13267591747271485707](https://jules.google.com/task/13267591747271485707) started by @zeyuz35*