### PR TITLE
⚙️ Modernizer: Replace magrittr pipes with native pipes in sagemaker_demo.R

### DIFF
--- a/R/AWS/sagemaker_demo.R
+++ b/R/AWS/sagemaker_demo.R
@@ -21,24 +21,24 @@ ggplot(abalone, aes(x = height, y = rings, color = sex)) + geom_point() + geom_j
 
 ## Cleaning
 
-abalone <- abalone %>%
+abalone <- abalone |>
   filter(height != 0)
 
-abalone <- abalone %>%
+abalone <- abalone |>
   mutate(female = as.integer(ifelse(sex == 'F', 1, 0)),
          male = as.integer(ifelse(sex == 'M', 1, 0)),
-         infant = as.integer(ifelse(sex == 'I', 1, 0))) %>%
+         infant = as.integer(ifelse(sex == 'I', 1, 0))) |>
   select(-sex)
-abalone <- abalone %>%
+abalone <- abalone |>
   select(rings:infant, length:shell_weight)
 head(abalone)
 
 ## Train/test split
 
-abalone_train <- abalone %>%
+abalone_train <- abalone |>
   sample_frac(size = 0.7)
 abalone <- anti_join(abalone, abalone_train)
-abalone_test <- abalone %>%
+abalone_test <- abalone |>
   sample_frac(size = 0.5)
 abalone_valid <- anti_join(abalone, abalone_test)
 


### PR DESCRIPTION
💡 What: Replace `%>%` with `|>` in `R/AWS/sagemaker_demo.R`
🎯 Why: Removes dependency on `magrittr`, uses base R 4.1.0+ native pipe for equivalent simple chaining without `.`
📊 Impact: Improves readability and removes an unnecessary dependency call. Less than 50 lines changed (12 changes).
✅ Verification: `Rscript -e "parse('R/AWS/sagemaker_demo.R')"` executed without any syntax errors. Pytest run completed successfully.

---
*PR created automatically by Jules for task [9298271950400371103](https://jules.google.com/task/9298271950400371103) started by @zeyuz35*