### PR TITLE
📝 Docent: [style fix] Convert cat() to message() in generalized_linear_model.R

### DIFF
--- a/R/xgboost/demo/generalized_linear_model.R
+++ b/R/xgboost/demo/generalized_linear_model.R
@@ -1,7 +1,7 @@
 require(xgboost)
 # load in the agaricus dataset
-data(agaricus.train, package='xgboost')
-data(agaricus.test, package='xgboost')
+data(agaricus.train, package = "xgboost")
+data(agaricus.test, package = "xgboost")
 dtrain <- xgb.DMatrix(agaricus.train$data, label = agaricus.train$label)
 dtest <- xgb.DMatrix(agaricus.test$data, label = agaricus.test$label)
 ##
@@ -11,14 +11,16 @@ dtest <- xgb.DMatrix(agaricus.test$data, label = agaricus.test$label)
 ##
 
 # change booster to gblinear, so that we are fitting a linear model
-# alpha is the L1 regularizer 
+# alpha is the L1 regularizer
 # lambda is the L2 regularizer
 # you can also set lambda_bias which is L2 regularizer on the bias term
-param <- list(objective = "binary:logistic", booster = "gblinear",
-              nthread = 2, alpha = 0.0001, lambda = 1)
+param <- list(
+  objective = "binary:logistic", booster = "gblinear",
+  nthread = 2, alpha = 0.0001, lambda = 1
+)
 
 # normally, you do not need to set eta (step_size)
-# XGBoost uses a parallel coordinate descent algorithm (shotgun), 
+# XGBoost uses a parallel coordinate descent algorithm (shotgun),
 # there could be affection on convergence with parallelization on certain cases
 # setting eta to be smaller value, e.g 0.5 can make the optimization more stable
 
@@ -29,6 +31,5 @@ watchlist <- list(eval = dtest, train = dtrain)
 num_round <- 2
 bst <- xgb.train(param, dtrain, num_round, watchlist)
 ypred <- predict(bst, dtest)
-labels <- getinfo(dtest, 'label')
-cat('error of preds=', mean(as.numeric(ypred>0.5)!=labels),'\n')
-
+labels <- getinfo(dtest, "label")
+message(paste0("error of preds=", mean(as.numeric(ypred > 0.5) != labels)))


### PR DESCRIPTION
💡 What: Convert `cat()` to `message()` and apply air/styler formatting.
🎯 Why: Code styling gap. `cat()` used for output instead of `message()`, formatting not strictly followed.
📊 Scope: `R/xgboost/demo/generalized_linear_model.R` modified. Diff < 50 lines.
✅ Verification: Syntax parsed correctly, `styler` completed successfully, tests passed.

---
*PR created automatically by Jules for task [389229505816060648](https://jules.google.com/task/389229505816060648) started by @zeyuz35*