### PR TITLE
⚙️ Modernizer: Rename single-letter iterators and generic args in xgboost demo

### DIFF
--- a/R/xgboost/demo/interaction_constraints.R
+++ b/R/xgboost/demo/interaction_constraints.R
@@ -10,8 +10,8 @@ treeInteractions <- function(input_tree, input_max_depth){
   if (nrow(input_tree) == 1) return(list())
 
   # Attach parent nodes
-  for (i in 2:input_max_depth){
-    if (i == 2) trees[, ID_merge:=ID] else trees[, ID_merge:=get(paste0('parent_',i-2))]
+  for (ii in 2:input_max_depth){
+    if (ii == 2) trees[, ID_merge:=ID] else trees[, ID_merge:=get(paste0('parent_',ii-2))]
     parents_left <- trees[!is.na(Split), list(i.id=ID, i.feature=Feature, ID_merge=Yes)]
     parents_right <- trees[!is.na(Split), list(i.id=ID, i.feature=Feature, ID_merge=No)]
 
@@ -20,11 +20,11 @@ treeInteractions <- function(input_tree, input_max_depth){
     setorderv(parents_right, 'ID_merge')
 
     trees <- merge(trees, parents_left, by='ID_merge', all.x=T)
-    trees[!is.na(i.id), c(paste0('parent_', i-1), paste0('parent_feat_', i-1)):=list(i.id, i.feature)]
+    trees[!is.na(i.id), c(paste0('parent_', ii-1), paste0('parent_feat_', ii-1)):=list(i.id, i.feature)]
     trees[, c('i.id','i.feature'):=NULL]
 
     trees <- merge(trees, parents_right, by='ID_merge', all.x=T)
-    trees[!is.na(i.id), c(paste0('parent_', i-1), paste0('parent_feat_', i-1)):=list(i.id, i.feature)]
+    trees[!is.na(i.id), c(paste0('parent_', ii-1), paste0('parent_feat_', ii-1)):=list(i.id, i.feature)]
     trees[, c('i.id','i.feature'):=NULL]
   }
 
@@ -35,7 +35,7 @@ treeInteractions <- function(input_tree, input_max_depth){
   interaction_list <- lapply(interaction_trees_split, as.character)
 
   # Remove NAs (no parent interaction)
-  interaction_list <- lapply(interaction_list, function(x) x[!is.na(x)])
+  interaction_list <- lapply(interaction_list, function(interaction_node) interaction_node[!is.na(interaction_node)])
 
   # Remove non-interactions (same variable)
   interaction_list <- lapply(interaction_list, unique)  # remove same variables
@@ -47,8 +47,8 @@ treeInteractions <- function(input_tree, input_max_depth){
 
 # Generate sample data
 x <- list()
-for (i in 1:10){
-  x[[i]] = i*rnorm(1000, 10)
+for (ii in 1:10){
+  x[[ii]] = ii*rnorm(1000, 10)
 }
 x <- as.data.table(x)
 
@@ -63,7 +63,7 @@ interaction_list <- list(c('V1','V2'),c('V3','V4','V5'))
 cols2ids <- function(object, col_names) {
   LUT <- seq_along(col_names) - 1
   names(LUT) <- col_names
-  rapply(object, function(x) LUT[x], classes="character", how="replace")
+  rapply(object, function(feature_name) LUT[feature_name], classes="character", how="replace")
 }
 interaction_list_fid = cols2ids(interaction_list, colnames(train))
 
@@ -93,13 +93,13 @@ bst3_interactions <- treeInteractions(bst3_tree, 4)  # interactions still constr
 
 # Show monotonic constraints still apply by checking scores after incrementing V1
 x1 <- sort(unique(x[['V1']]))
-for (i in 1:length(x1)){
+for (ii in 1:length(x1)){
   testdata <- copy(x[, -c('V1')])
-  testdata[['V1']] <- x1[i]
+  testdata[['V1']] <- x1[ii]
   testdata <- testdata[, paste0('V',1:10), with=F]
   pred <- predict(bst3, as.matrix(testdata))
   
   # Should not print out anything due to monotonic constraints
-  if (i > 1) if (any(pred > prev_pred)) print(i)
+  if (ii > 1) if (any(pred > prev_pred)) print(ii)
   prev_pred <- pred 
 }


### PR DESCRIPTION
💡 **What:** Renamed single-letter loop iterators (`i` -> `ii`) and generic anonymous function arguments (`x` -> `interaction_node`/`feature_name`) in `R/xgboost/demo/interaction_constraints.R`.
🎯 **Why:** To improve maintainability and searchability, avoiding scope collision with other variables, while strictly preserving exact functionality. Data.table column references like `i.id` and `i.feature` were explicitly preserved.
📊 **Impact:** Enhances code clarity and debugging without any performance or logic alterations.
✅ **Verification:** Ran `Rscript -e "parse('R/xgboost/demo/interaction_constraints.R')"` to confirm no syntax errors, ran `pytest` for the standard test execution step, and confirmed the diff exactly matched the targeted 11-line modification.

---
*PR created automatically by Jules for task [389820664699985227](https://jules.google.com/task/389820664699985227) started by @zeyuz35*