### PR TITLE
🗃️ Curator: Fix silent type coercion in list-column initialization for JSON serialization

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,4 @@
+## 2026-05-10 - Safe Initialization of List-Columns in R
+
+**Learning:** When creating `data.frame`s intended for JSON serialization via `jsonlite`, initializing a column as numeric (e.g., `target = c(1:N)`) and later trying to insert arrays/lists into its rows (`df$target[i] <- list(array_data)`) triggers silent type coercion or an outright execution crash (`more elements supplied than there are to replace`).
+**Action:** When a column is meant to hold nested data (lists or arrays), always initialize it explicitly as a list vector: `df$column <- vector("list", N)`.

--- a/R/AWS/sagemaker.R
+++ b/R/AWS/sagemaker.R
@@ -157,9 +157,9 @@ tidy_to_json <- function(data, start) {
   cross_units <- length(stock_id)
   
   ## JUst setting the beginning time to something arbitrary for now, change if needed
-  pooled_panel_json <- data.frame(start = rep(start, cross_units), 
-                                  target = c(1:cross_units), 
-                                  dynamic_feat = c(1:cross_units))
+  pooled_panel_json <- data.frame(start = rep(start, cross_units))
+  pooled_panel_json$target <- vector("list", cross_units)
+  pooled_panel_json$dynamic_feat <- vector("list", cross_units)
   
   pooled_panel_json <- foreach(i = 1:cross_units, .combine = "rbind") %dopar% {
     df <- data.frame(start = 0, target = 0, dynamic_feat = 0)
@@ -323,9 +323,9 @@ tidy_to_batch_inf <- function(data, start, timeSlices, set) {
   cross_units <- length(stock_id)
   
   ## Just setting the beginning time to something arbitrary for now, change if needed
-  pooled_panel_json <- data.frame(start = rep(start, cross_units), 
-                                  target = c(1:cross_units), 
-                                  dynamic_feat = c(1:cross_units))
+  pooled_panel_json <- data.frame(start = rep(start, cross_units))
+  pooled_panel_json$target <- vector("list", cross_units)
+  pooled_panel_json$dynamic_feat <- vector("list", cross_units)
   
   for (i in 1:cross_units) {
     pooled_panel_filter <- data %>%


### PR DESCRIPTION
💡 **What**: Refactored the initialization of the `target` and `dynamic_feat` columns in `R/AWS/sagemaker.R` from numeric vectors (`c(1:cross_units)`) to list columns (`vector("list", cross_units)`).

🎯 **Why**: In R, assigning a list of values to a single element of an atomic integer vector triggers a runtime crash or silent coercion. AWS SageMaker DeepAR expects JSON targets to be arrays, requiring list-columns. The previous initialization logic was flawed and caused `data.frame` assignment crashes.

📊 **Impact**: Prevents execution errors during the AWS DeepAR dataset transformation loop, enabling the creation of valid, robust JSON structures without data loss.

✅ **Verification**:
- Created local test reproduction confirming crash under old logic and success under new logic.
- Parsed the updated `R/AWS/sagemaker.R` script ensuring no syntax regressions.
- Passed `pytest` collection (0 items as expected).

---
*PR created automatically by Jules for task [6339235174887484176](https://jules.google.com/task/6339235174887484176) started by @zeyuz35*