### PR TITLE
📝 Docent: Replace print with message for informational logs

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2024-05-13 - Replace base print() with message() in R
+**Learning:** R demo scripts often use print() or cat() to output informational steps. The standard in R programming is to use message() for diagnostics and informational logging, as print() should be reserved for outputting values, and cat() for console formatting.
+**Action:** Replace `print("info")` and `print(paste("var=", err))` calls with `message("info")` and `message(paste0("var=", err))` in the demo file `R/xgboost/demo/basic_walkthrough.R` to align with R's professional diagnostic message standard, which is under 50 lines.

--- a/R/xgboost/demo/basic_walkthrough.R
+++ b/R/xgboost/demo/basic_walkthrough.R
@@ -15,28 +15,28 @@ class(train$data)
 # this is the basic usage of xgboost you can put matrix in data field
 # note: we are putting in sparse matrix here, xgboost naturally handles sparse input
 # use sparse matrix when your feature is sparse(e.g. when you are using one-hot encoding vector)
-print("Training xgboost with sparseMatrix")
+message("Training xgboost with sparseMatrix")
 bst <- xgboost(data = train$data, label = train$label, max_depth = 2, eta = 1, nrounds = 2,
                nthread = 2, objective = "binary:logistic")
 # alternatively, you can put in dense matrix, i.e. basic R-matrix
-print("Training xgboost with Matrix")
+message("Training xgboost with Matrix")
 bst <- xgboost(data = as.matrix(train$data), label = train$label, max_depth = 2, eta = 1, nrounds = 2,
                nthread = 2, objective = "binary:logistic")
 
 # you can also put in xgb.DMatrix object, which stores label, data and other meta datas needed for advanced features
-print("Training xgboost with xgb.DMatrix")
+message("Training xgboost with xgb.DMatrix")
 dtrain <- xgb.DMatrix(data = train$data, label = train$label)
 bst <- xgboost(data = dtrain, max_depth = 2, eta = 1, nrounds = 2, nthread = 2, 
                objective = "binary:logistic")
 
 # Verbose = 0,1,2
-print("Train xgboost with verbose 0, no message")
+message("Train xgboost with verbose 0, no message")
 bst <- xgboost(data = dtrain, max_depth = 2, eta = 1, nrounds = 2,
                nthread = 2, objective = "binary:logistic", verbose = 0)
-print("Train xgboost with verbose 1, print evaluation metric")
+message("Train xgboost with verbose 1, print evaluation metric")
 bst <- xgboost(data = dtrain, max_depth = 2, eta = 1, nrounds = 2,
                nthread = 2, objective = "binary:logistic", verbose = 1)
-print("Train xgboost with verbose 2, also print information about tree")
+message("Train xgboost with verbose 2, also print information about tree")
 bst <- xgboost(data = dtrain, max_depth = 2, eta = 1, nrounds = 2,
                nthread = 2, objective = "binary:logistic", verbose = 2)
 
@@ -49,7 +49,7 @@ bst <- xgboost(data = dtrain, max_depth = 2, eta = 1, nrounds = 2,
 # you can put in Matrix, sparseMatrix, or xgb.DMatrix 
 pred <- predict(bst, test$data)
 err <- mean(as.numeric(pred > 0.5) != test$label)
-print(paste("test-error=", err))
+message(paste0("test-error=", err))
 
 #-------------------save and load models-------------------------
 # save model to binary local file
@@ -58,7 +58,7 @@ xgb.save(bst, "xgboost.model")
 bst2 <- xgb.load("xgboost.model")
 pred2 <- predict(bst2, test$data)
 # pred2 should be identical to pred
-print(paste("sum(abs(pred2-pred))=", sum(abs(pred2-pred))))
+message(paste0("sum(abs(pred2-pred))=", sum(abs(pred2-pred))))
 
 # save model to R's raw vector
 raw = xgb.save.raw(bst)
@@ -66,7 +66,7 @@ raw = xgb.save.raw(bst)
 bst3 <- xgb.load(raw)
 pred3 <- predict(bst3, test$data)
 # pred3 should be identical to pred
-print(paste("sum(abs(pred3-pred))=", sum(abs(pred3-pred))))
+message(paste0("sum(abs(pred3-pred))=", sum(abs(pred3-pred))))
 
 #----------------Advanced features --------------
 # to use advanced features, we need to put data in xgb.DMatrix
@@ -77,11 +77,11 @@ dtest <- xgb.DMatrix(data = test$data, label=test$label)
 watchlist <- list(train=dtrain, test=dtest)
 # to train with watchlist, use xgb.train, which contains more advanced features
 # watchlist allows us to monitor the evaluation result on all data in the list 
-print("Train xgboost using xgb.train with watchlist")
+message("Train xgboost using xgb.train with watchlist")
 bst <- xgb.train(data=dtrain, max_depth=2, eta=1, nrounds=2, watchlist=watchlist,
                  nthread = 2, objective = "binary:logistic")
 # we can change evaluation metrics, or use multiple evaluation metrics
-print("train xgboost using xgb.train with watchlist, watch logloss and error")
+message("train xgboost using xgb.train with watchlist, watch logloss and error")
 bst <- xgb.train(data=dtrain, max_depth=2, eta=1, nrounds=2, watchlist=watchlist,
                  eval_metric = "error", eval_metric = "logloss",
                  nthread = 2, objective = "binary:logistic")
@@ -96,17 +96,17 @@ bst <- xgb.train(data=dtrain2, max_depth=2, eta=1, nrounds=2, watchlist=watchlis
 label = getinfo(dtest, "label")
 pred <- predict(bst, dtest)
 err <- as.numeric(sum(as.integer(pred > 0.5) != label))/length(label)
-print(paste("test-error=", err))
+message(paste0("test-error=", err))
 
 # You can dump the tree you learned using xgb.dump into a text file
 dump_path = file.path(tempdir(), 'dump.raw.txt')
 xgb.dump(bst, dump_path, with_stats = T)
 
 # Finally, you can check which features are the most important.
-print("Most important features (look at column Gain):")
+message("Most important features (look at column Gain):")
 imp_matrix <- xgb.importance(feature_names = colnames(train$data), model = bst)
 print(imp_matrix)
 
 # Feature importance bar plot by gain
-print("Feature importance Plot : ")
+message("Feature importance Plot : ")
 print(xgb.plot.importance(importance_matrix = imp_matrix))


### PR DESCRIPTION
💡 **What**: Replaced raw `print()` and `print(paste(...))` calls with `message()` and `message(paste0(...))` for informational steps in `R/xgboost/demo/basic_walkthrough.R`.
🎯 **Why**: In R, `message()` is the standard and professional way to output diagnostic and informational logs, whereas `print()` should be reserved for outputting values/objects to the console.
📊 **Scope**: Modifications are localized to `R/xgboost/demo/basic_walkthrough.R` and affect < 50 lines. Added a Docent journal entry in `.jules/docent.md`.
✅ **Verification**: Verified syntactical correctness via `parse('R/xgboost/demo/basic_walkthrough.R')`.

---
*PR created automatically by Jules for task [3070527167796728806](https://jules.google.com/task/3070527167796728806) started by @zeyuz35*