### PR TITLE
⚙️ Modernizer: [performance improvement: avoid growing object]

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,1 +1,6 @@
 ## Modernizer Journal
+
+## 2024-05-13 - Replace iterative rbind() with do.call(rbind, lapply()) in R
+
+**Learning:** Iteratively calling `rbind()` inside a `for` loop in R is an $O(N^2)$ operation that is extremely slow because it repeatedly copies the growing dataframe in memory.
+**Action:** Replaced `for` loop `rbind()` accumulation with `lapply` to collect dataframes in a list and combined them once using `do.call(rbind, list)`.

--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -815,10 +815,9 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(1:length(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
@@ -956,10 +955,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_grid <- do.call(rbind, lapply(RF_model_grid, function(x) x$RF_grid))
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/ff_factors/Real Data.Rmd
+++ b/R/empirical_robustness/ff_factors/Real Data.Rmd
@@ -868,10 +868,9 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(1:length(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
@@ -1009,10 +1008,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_grid <- do.call(rbind, lapply(RF_model_grid, function(x) x$RF_grid))
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/missing_threshold/Real Data.Rmd
+++ b/R/empirical_robustness/missing_threshold/Real Data.Rmd
@@ -816,10 +816,9 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(1:length(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
@@ -957,10 +956,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_grid <- do.call(rbind, lapply(RF_model_grid, function(x) x$RF_grid))
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/train_valid_1/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_1/Real Data.Rmd
@@ -813,10 +813,9 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(1:length(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
@@ -954,10 +953,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_grid <- do.call(rbind, lapply(RF_model_grid, function(x) x$RF_grid))
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/train_valid_2/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_2/Real Data.Rmd
@@ -818,10 +818,9 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(1:length(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
@@ -961,10 +960,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_grid <- do.call(rbind, lapply(RF_model_grid, function(x) x$RF_grid))
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -453,10 +453,9 @@ ELN_model_grid <- function(ELN_grid, train_x, train_y, validation_x, validation_
 }
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(1:length(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
@@ -582,10 +581,9 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(1:length(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
@@ -801,10 +799,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_grid <- do.call(rbind, lapply(RF_model_grid, function(x) x$RF_grid))
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 


### PR DESCRIPTION
**What:** Replaced iterative `rbind()` accumulation inside `for` loops with `do.call(rbind, lapply(...))` across multiple RMarkdown files for Elastic Net and Random Forest parameter grid setups.

**Why:** Iterative `rbind()` in R scales $O(N^2)$ because it creates a new copy of the growing dataframe on every iteration. This is a well-known anti-pattern. `do.call(rbind, lapply(...))` allocates all dataframes into a list and binds them all at once.

**Impact:** Dramatically improves execution time and reduces memory bloat during hyperparameter model grid preparation for Elastic Net and Random Forest modeling steps. 

**Verification:** Parsed the generated R code from all modified `.Rmd` files using `Rscript -e "parse()"` successfully to ensure no syntax regressions were introduced. Passed automated syntax checks and verified visually.

**Learnings Recorded:** Updated `.jules/modernizer.md` with notes on identifying and refactoring this specific loop accumulation performance bottleneck.

---
*PR created automatically by Jules for task [9579294349778982855](https://jules.google.com/task/9579294349778982855) started by @zeyuz35*