### PR TITLE
⚡ Bolt: Optimize iterative rbind loops with lapply

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Optimize iterative rbind loops
+**Learning:** Using `rbind` inside a `for` loop creates an O(N^2) bottleneck due to repeated memory reallocation and copying.
+**Action:** Replaced iterative `rbind` with `do.call(rbind, lapply(...))` to accumulate results efficiently in `get_ELN_best_tune` and `get_RF_best_tune` functions.

--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -815,10 +815,9 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
@@ -956,10 +955,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_grid <- do.call(rbind, lapply(RF_model_grid, function(x) x$RF_grid))
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/ff_factors/Real Data.Rmd
+++ b/R/empirical_robustness/ff_factors/Real Data.Rmd
@@ -868,10 +868,9 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
@@ -1009,10 +1008,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_grid <- do.call(rbind, lapply(RF_model_grid, function(x) x$RF_grid))
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/missing_threshold/Real Data.Rmd
+++ b/R/empirical_robustness/missing_threshold/Real Data.Rmd
@@ -816,10 +816,9 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
@@ -957,10 +956,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_grid <- do.call(rbind, lapply(RF_model_grid, function(x) x$RF_grid))
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/train_valid_1/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_1/Real Data.Rmd
@@ -813,10 +813,9 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
@@ -954,10 +953,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_grid <- do.call(rbind, lapply(RF_model_grid, function(x) x$RF_grid))
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/train_valid_2/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_2/Real Data.Rmd
@@ -818,10 +818,9 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
@@ -961,10 +960,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_grid <- do.call(rbind, lapply(RF_model_grid, function(x) x$RF_grid))
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -453,10 +453,9 @@ ELN_model_grid <- function(ELN_grid, train_x, train_y, validation_x, validation_
 }
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
@@ -582,10 +581,9 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
@@ -801,10 +799,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_grid <- do.call(rbind, lapply(RF_model_grid, function(x) x$RF_grid))
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 


### PR DESCRIPTION
💡 **What:** Replaced iterative `rbind()` inside `for` loops with `do.call(rbind, lapply(...))` in `get_ELN_best_tune` and `get_RF_best_tune` across multiple `.Rmd` files.
🎯 **Why:** Using `rbind()` in a loop creates an O(N^2) performance bottleneck due to continuous memory reallocation. List accumulation is significantly faster.
📊 **Impact:** Faster hyperparameter tuning data aggregation, especially when the `model_grid` grows large.
✅ **Verification:** Extracted R code from `.Rmd` files using `knitr::purl()` and ran static syntax checks (`parse()`) to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [12244867774196484909](https://jules.google.com/task/12244867774196484909) started by @zeyuz35*