### PR TITLE
⚙️ Modernizer: [Replace 1:length with seq_along iterator update]

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,1 +1,3 @@
-## Modernizer Journal
+## 2024-05-24 - [Replace 1:length(...) with seq_along(...)]
+**Learning:** Legacy iterator syntax `1:length(x)` can cause errors when `x` has length 0, evaluating to `1:0`. Using `seq_along(x)` is the modern, idiomatic R pattern that safely handles 0-length vectors and clearly signals intent.
+**Action:** Replaced instances of `1:length(...)` with `seq_along(...)` across all R and Rmd scripts to modernize loop patterns, improve robustness, and maintain existing performance logic without altering intended behavior.

--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -150,7 +150,7 @@ time_df <- data.frame(time = unique(datashare$time)) %>%
 ## This approach keeps a highly variable number of stocks, depending on when you filter the data from
 ## Going with a filter of >= 1993.5 gives us 195 unique stocks, just going with this for now for feasibility
 
-datashare <- foreach(i = (1:length(unique(datashare$stock))), .combine = "rbind") %dopar% {
+datashare <- foreach(i = (seq_along(unique(datashare$stock))), .combine = "rbind") %dopar% {
   datashare_stock <- datashare %>%
     mutate(time = as.numeric(time)) %>%
     filter(stock == unique(datashare$stock)[i]) %>%
@@ -171,7 +171,7 @@ length(unique(datashare$stock))
 ## Sensible, because companies can be bought out and floated again, etc.
 ## Not likely to make a huge difference, but actual quarterly returns are computed, instead of log quarterly returns
 ## This is because stock prices can in some cases have rather large movements over a quarter
-# datashare <- foreach(i = (1:length(unique(datashare$stock))), .combine = rbind) %dopar% {
+# datashare <- foreach(i = (seq_along(unique(datashare$stock))), .combine = rbind) %dopar% {
 #   datashare_stock <- datashare %>%
 #     mutate(time = as.numeric(time)) %>%
 #     filter(stock == unique(datashare$stock)[i]) %>%
@@ -227,7 +227,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   time_periods <- unique(dataset$time)
   
-  cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  cross_sectional_values_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
@@ -262,7 +262,7 @@ colnames(test)[colSums(is.na(test)) > 0]
 impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
-  imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  imputed_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -302,7 +302,7 @@ ncol(datashare_filtered)
 cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
-  normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  normalize_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -420,7 +420,7 @@ write.csv(individual_factor_names, file = "individual_factor_names.csv")
 ## This section builds in the macro dataset and egnerates the interaction terms
 interaction_terms <- rep(list(0), length(macro_factor_names))
 
-for (i in 1:length(macro_factor_names)) {
+for (i in seq_along(macro_factor_names)) {
   interaction_terms[[i]] <- paste(macro_factor_names[i], individual_factor_names, sep = ":", collapse = " + ")
 }
 
@@ -634,7 +634,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -653,7 +653,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -675,7 +675,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -694,7 +694,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -786,7 +786,7 @@ LM_fit <- function(pooled_panel, timeSlices, loss_function, f,
 
 ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validation_y, loss_function, nlamb) {
   
-  ELN_model_grid_list <- foreach(i = (1:length(alpha_grid))) %dopar% {
+  ELN_model_grid_list <- foreach(i = (seq_along(alpha_grid))) %dopar% {
     ELN_model_grid <- list(ELN_grid = 0, model = 0)
     
     #MSE Case

--- a/R/empirical_robustness/ff_factors/Real Data.Rmd
+++ b/R/empirical_robustness/ff_factors/Real Data.Rmd
@@ -152,7 +152,7 @@ time_df <- data.frame(time = unique(datashare$time)) %>%
 
 options(future.globals.maxSize = 3e+9)
 
-datashare <- foreach(i = (1:length(unique(datashare$stock))), .combine = "rbind") %dopar% {
+datashare <- foreach(i = (seq_along(unique(datashare$stock))), .combine = "rbind") %dopar% {
   datashare_stock <- datashare %>%
     mutate(time = as.numeric(time)) %>%
     filter(stock == unique(datashare$stock)[i]) %>%
@@ -177,7 +177,7 @@ length(unique(datashare$stock))
 ## Sensible, because companies can be bought out and floated again, etc.
 ## Not likely to make a huge difference, but actual quarterly returns are computed, instead of log quarterly returns
 ## This is because stock prices can in some cases have rather large movements over a quarter
-# datashare <- foreach(i = (1:length(unique(datashare$stock))), .combine = rbind) %dopar% {
+# datashare <- foreach(i = (seq_along(unique(datashare$stock))), .combine = rbind) %dopar% {
 #   datashare_stock <- datashare %>%
 #     mutate(time = as.numeric(time)) %>%
 #     filter(stock == unique(datashare$stock)[i]) %>%
@@ -233,7 +233,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   time_periods <- unique(dataset$time)
   
-  cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  cross_sectional_values_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
@@ -268,7 +268,7 @@ colnames(test)[colSums(is.na(test)) > 0]
 impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
-  imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  imputed_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -308,7 +308,7 @@ ncol(datashare_filtered)
 cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
-  normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  normalize_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -469,7 +469,7 @@ write.csv(individual_factor_names, file = "individual_factor_names.csv")
 ## This section builds in the macro dataset and egnerates the interaction terms
 interaction_terms <- rep(list(0), length(macro_factor_names))
 
-for (i in 1:length(macro_factor_names)) {
+for (i in seq_along(macro_factor_names)) {
   interaction_terms[[i]] <- paste(macro_factor_names[i], individual_factor_names, sep = ":", collapse = " + ")
 }
 
@@ -687,7 +687,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -706,7 +706,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -728,7 +728,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -747,7 +747,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -839,7 +839,7 @@ LM_fit <- function(pooled_panel, timeSlices, loss_function, f,
 
 ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validation_y, loss_function, nlamb) {
   
-  ELN_model_grid_list <- foreach(i = (1:length(alpha_grid))) %dopar% {
+  ELN_model_grid_list <- foreach(i = (seq_along(alpha_grid))) %dopar% {
     ELN_model_grid <- list(ELN_grid = 0, model = 0)
     
     #MSE Case

--- a/R/empirical_robustness/missing_threshold/Real Data.Rmd
+++ b/R/empirical_robustness/missing_threshold/Real Data.Rmd
@@ -146,7 +146,7 @@ time_df <- data.frame(time = unique(datashare$time)) %>%
 ## Otherwise, you will inadventerdently filter out so that only stocks that have been listed on the exchange since the begginning are included
 ## The old apparoch kept ~ 20000 unique stocks
 
-datashare <- foreach(i = (1:length(unique(datashare$stock))), .combine = "rbind") %dopar% {
+datashare <- foreach(i = (seq_along(unique(datashare$stock))), .combine = "rbind") %dopar% {
   datashare_stock <- datashare %>%
     mutate(time = as.numeric(time)) %>%
     filter(stock == unique(datashare$stock)[i]) %>%
@@ -167,7 +167,7 @@ length(unique(datashare$stock))
 ## Sensible, because companies can be bought out and floated again, etc.
 ## Not likely to make a huge difference, but actual quarterly returns are computed, instead of log quarterly returns
 ## This is because stock prices can in some cases have rather large movements over a quarter
-# datashare <- foreach(i = (1:length(unique(datashare$stock))), .combine = rbind) %dopar% {
+# datashare <- foreach(i = (seq_along(unique(datashare$stock))), .combine = rbind) %dopar% {
 #   datashare_stock <- datashare %>%
 #     mutate(time = as.numeric(time)) %>%
 #     filter(stock == unique(datashare$stock)[i]) %>%
@@ -226,7 +226,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   time_periods <- unique(dataset$time)
   
-  cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  cross_sectional_values_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
@@ -261,7 +261,7 @@ colnames(test)[colSums(is.na(test)) > 0]
 impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
-  imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  imputed_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -301,7 +301,7 @@ ncol(datashare_filtered)
 cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
-  normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  normalize_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -419,7 +419,7 @@ write.csv(individual_factor_names, file = "individual_factor_names.csv")
 ## This section builds in the macro dataset and egnerates the interaction terms
 interaction_terms <- rep(list(0), length(macro_factor_names))
 
-for (i in 1:length(macro_factor_names)) {
+for (i in seq_along(macro_factor_names)) {
   interaction_terms[[i]] <- paste(macro_factor_names[i], individual_factor_names, sep = ":", collapse = " + ")
 }
 
@@ -633,7 +633,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -652,7 +652,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -674,7 +674,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -693,7 +693,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -787,7 +787,7 @@ LM_fit <- function(pooled_panel, timeSlices, loss_function, f,
 ```{r}
 ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validation_y, loss_function, nlamb) {
   
-  ELN_model_grid_list <- foreach(i = (1:length(alpha_grid)), .packages = c("hqreg")) %dopar% {
+  ELN_model_grid_list <- foreach(i = (seq_along(alpha_grid)), .packages = c("hqreg")) %dopar% {
     ELN_model_grid <- list(ELN_grid = 0, model = 0)
     
     #MSE Case

--- a/R/empirical_robustness/train_valid_1/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_1/Real Data.Rmd
@@ -148,7 +148,7 @@ time_df <- data.frame(time = unique(datashare$time)) %>%
 ## This approach keeps a highly variable number of stocks, depending on when you filter the data from
 ## Going with a filter of >= 1993.5 gives us 195 unique stocks, just going with this for now for feasibility
 
-datashare <- foreach(i = (1:length(unique(datashare$stock))), .combine = "rbind") %dopar% {
+datashare <- foreach(i = (seq_along(unique(datashare$stock))), .combine = "rbind") %dopar% {
   datashare_stock <- datashare %>%
     mutate(time = as.numeric(time)) %>%
     filter(stock == unique(datashare$stock)[i]) %>%
@@ -168,7 +168,7 @@ length(unique(datashare$stock))
 ## Sensible, because companies can be bought out and floated again, etc.
 ## Not likely to make a huge difference, but actual quarterly returns are computed, instead of log quarterly returns
 ## This is because stock prices can in some cases have rather large movements over a quarter
-# datashare <- foreach(i = (1:length(unique(datashare$stock))), .combine = rbind) %dopar% {
+# datashare <- foreach(i = (seq_along(unique(datashare$stock))), .combine = rbind) %dopar% {
 #   datashare_stock <- datashare %>%
 #     mutate(time = as.numeric(time)) %>%
 #     filter(stock == unique(datashare$stock)[i]) %>%
@@ -224,7 +224,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   time_periods <- unique(dataset$time)
   
-  cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  cross_sectional_values_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
@@ -259,7 +259,7 @@ colnames(test)[colSums(is.na(test)) > 0]
 impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
-  imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  imputed_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -299,7 +299,7 @@ ncol(datashare_filtered)
 cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
-  normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  normalize_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -417,7 +417,7 @@ write.csv(individual_factor_names, file = "individual_factor_names.csv")
 ## This section builds in the macro dataset and egnerates the interaction terms
 interaction_terms <- rep(list(0), length(macro_factor_names))
 
-for (i in 1:length(macro_factor_names)) {
+for (i in seq_along(macro_factor_names)) {
   interaction_terms[[i]] <- paste(macro_factor_names[i], individual_factor_names, sep = ":", collapse = " + ")
 }
 
@@ -631,7 +631,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %dopar% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %dopar% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -650,7 +650,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %dopar% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %dopar% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -672,7 +672,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -691,7 +691,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -783,7 +783,7 @@ LM_fit <- function(pooled_panel, timeSlices, loss_function, f,
 
 ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validation_y, loss_function, nlamb) {
   
-  ELN_model_grid_list <- foreach(i = (1:length(alpha_grid))) %dopar% {
+  ELN_model_grid_list <- foreach(i = (seq_along(alpha_grid))) %dopar% {
     ELN_model_grid <- list(ELN_grid = 0, model = 0)
     
     #MSE Case

--- a/R/empirical_robustness/train_valid_2/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_2/Real Data.Rmd
@@ -150,7 +150,7 @@ time_df <- data.frame(time = unique(datashare$time)) %>%
 ## This approach keeps a highly variable number of stocks, depending on when you filter the data from
 ## Going with a filter of >= 1993.5 gives us 195 unique stocks, just going with this for now for feasibility
 
-datashare <- foreach(i = (1:length(unique(datashare$stock))), .combine = "rbind") %dopar% {
+datashare <- foreach(i = (seq_along(unique(datashare$stock))), .combine = "rbind") %dopar% {
   datashare_stock <- datashare %>%
     mutate(time = as.numeric(time)) %>%
     filter(stock == unique(datashare$stock)[i]) %>%
@@ -170,7 +170,7 @@ length(unique(datashare$stock))
 ## Sensible, because companies can be bought out and floated again, etc.
 ## Not likely to make a huge difference, but actual quarterly returns are computed, instead of log quarterly returns
 ## This is because stock prices can in some cases have rather large movements over a quarter
-# datashare <- foreach(i = (1:length(unique(datashare$stock))), .combine = rbind) %dopar% {
+# datashare <- foreach(i = (seq_along(unique(datashare$stock))), .combine = rbind) %dopar% {
 #   datashare_stock <- datashare %>%
 #     mutate(time = as.numeric(time)) %>%
 #     filter(stock == unique(datashare$stock)[i]) %>%
@@ -226,7 +226,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   time_periods <- unique(dataset$time)
   
-  cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  cross_sectional_values_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
@@ -261,7 +261,7 @@ colnames(test)[colSums(is.na(test)) > 0]
 impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
-  imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  imputed_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -301,7 +301,7 @@ ncol(datashare_filtered)
 cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
-  normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  normalize_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -419,7 +419,7 @@ write.csv(individual_factor_names, file = "individual_factor_names.csv")
 ## This section builds in the macro dataset and egnerates the interaction terms
 interaction_terms <- rep(list(0), length(macro_factor_names))
 
-for (i in 1:length(macro_factor_names)) {
+for (i in seq_along(macro_factor_names)) {
   interaction_terms[[i]] <- paste(macro_factor_names[i], individual_factor_names, sep = ":", collapse = " + ")
 }
 
@@ -633,7 +633,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %dopar% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %dopar% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -652,7 +652,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %dopar% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %dopar% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -678,7 +678,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -697,7 +697,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -789,7 +789,7 @@ LM_fit <- function(pooled_panel, timeSlices, loss_function, f,
 
 ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validation_y, loss_function, nlamb) {
   
-  ELN_model_grid_list <- foreach(i = (1:length(alpha_grid))) %dopar% {
+  ELN_model_grid_list <- foreach(i = (seq_along(alpha_grid))) %dopar% {
     ELN_model_grid <- list(ELN_grid = 0, model = 0)
     
     #MSE Case

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -211,7 +211,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -230,7 +230,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -252,7 +252,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -271,7 +271,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -553,7 +553,7 @@ alpha_grid <- seq(0, 1, 0.01)
 
 ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validation_y, loss_function, nlamb) {
   
-  ELN_model_grid_list <- foreach(i = (1:length(alpha_grid))) %dopar% {
+  ELN_model_grid_list <- foreach(i = (seq_along(alpha_grid))) %dopar% {
     ELN_model_grid <- list(ELN_grid = 0, model = 0)
     
     #MSE Case
@@ -1624,7 +1624,7 @@ fforma_fit_individual <- function(panel, timeSlices, set) {
                                              dplyr::select(-rt, -stock, -time), model = umap_model)
   
   ## 
-  dataset_list <- foreach(i = 1:length(unique(pooled_panel$stock))) %dopar% {
+  dataset_list <- foreach(i = seq_along(unique(pooled_panel$stock))) %dopar% {
     stock_id <- unique(pooled_panel$stock)
 
     time_series <- pooled_panel_train %>%
@@ -1847,7 +1847,7 @@ fforma_fit_individual <- function(panel, timeSlices, set) {
 ## Function to return a data matrix with features extracted via tsfeatures, one series per row, given panel data
 # Remeber that this function doesn't do train/validation/split, so you'll have to do these outside of it
 fforma_data_matrix <- function(pooled_panel) {
-  data <- foreach(i = 1:length(unique(pooled_panel$stock)), .combine = "rbind") %do% {
+  data <- foreach(i = seq_along(unique(pooled_panel$stock)), .combine = "rbind") %do% {
   stock_id <- unique(pooled_panel$stock)
 
   univariate_time_series <- pooled_panel %>%
@@ -1863,7 +1863,7 @@ fforma_data_matrix <- function(pooled_panel) {
 ## Function to return an errors matrix
 
 fforma_errors <- function(fforma_fit, loss_function) {
-  foreach(i = 1:length(fforma_fit), .combine = "rbind") %do% {
+  foreach(i = seq_along(fforma_fit), .combine = "rbind") %do% {
     # MSE
     if (loss_function == "mse") {
       fforma_fit[[i]]$validation_error_mse
@@ -1953,7 +1953,7 @@ error_softmax_obj <- function(preds, dtrain) {
 fforma_fit_stats <- function(pooled_panel, timeSlices, loss_function) {
   fforma_fit_stats_list <- rep(list(0), length(timeSlices))
   
-  for (set in 1:length(fforma_fit_stats_list)) {
+  for (set in seq_along(fforma_fit_stats_list)) {
     fforma_fit_stats_list[[set]] <- list(loss_stats = data.frame(train_MAE = 0, train_MSE = 0, 
                                                                  train_RMSE = 0, train_RSquare = 0, 
                                                                  validation_MAE = 0, validation_MSE = 0,

--- a/R/xgboost/demo/interaction_constraints.R
+++ b/R/xgboost/demo/interaction_constraints.R
@@ -93,7 +93,7 @@ bst3_interactions <- treeInteractions(bst3_tree, 4)  # interactions still constr
 
 # Show monotonic constraints still apply by checking scores after incrementing V1
 x1 <- sort(unique(x[['V1']]))
-for (i in 1:length(x1)){
+for (i in seq_along(x1)){
   testdata <- copy(x[, -c('V1')])
   testdata[['V1']] <- x1[i]
   testdata <- testdata[, paste0('V',1:10), with=F]


### PR DESCRIPTION
💡 **What**: Replaced instances of `1:length(...)` with `seq_along(...)` across all R scripts and R Markdown files in the repository. Additionally added `.jules/modernizer.md` detailing the modernization process.
🎯 **Why**: Legacy iterator syntax `1:length(x)` evaluates to `1:0` when `x` is an empty (zero-length) vector or object, which leads to unpredictable behavior or errors by executing the loop for `1` and `0` when it should skip execution completely. The modern, idiomatic `seq_along(x)` handles zero-length edge cases flawlessly by returning a 0-length integer vector, preventing out-of-bounds execution and acting as clearer documentation for intent.
📊 **Impact**: Safely updates widespread loop constructs across the codebase, effectively immunizing it against zero-length iteration bugs without altering loop performance or functional outcome. Maintainability is significantly improved by converting these legacy loops into a cleaner standard R pattern.
✅ **Verification**:
- R Scripts (`.R`) were parsed successfully with `parse()`.
- R Markdown files (`.Rmd`) were successfully purled to pure R via `knitr::purl()` and verified valid syntactically via `parse()`.
- Verified changes visually through `git diff` confirming that the functionality inside the loops was kept intact.

---
*PR created automatically by Jules for task [14738089241277737075](https://jules.google.com/task/14738089241277737075) started by @zeyuz35*