### PR TITLE
📝 Docent: Replace cat() with message() for professional logging

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - R message() formatting
+**Learning:** When replacing raw `cat(".")` output with `message()`, `message(".", appendLF = FALSE)` accurately replicates the inline behavior of `cat(".")` for progress indications. Also, empty `cat("\n")` should be replaced with `message("")`. `knitr::purl()` might fail if `.Rmd` chunks have duplicated chunk names.
+**Action:** Use these exact replacements in R packages/scripts. Use manual static syntax validation if `knitr::purl` encounters syntax or metadata issues.

--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -1116,8 +1116,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/empirical_robustness/ff_factors/Real Data.Rmd
+++ b/R/empirical_robustness/ff_factors/Real Data.Rmd
@@ -1167,8 +1167,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/empirical_robustness/missing_threshold/Real Data.Rmd
+++ b/R/empirical_robustness/missing_threshold/Real Data.Rmd
@@ -1117,8 +1117,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/empirical_robustness/train_valid_1/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_1/Real Data.Rmd
@@ -1112,8 +1112,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/empirical_robustness/train_valid_2/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_2/Real Data.Rmd
@@ -1119,8 +1119,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -989,8 +989,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     
@@ -1438,8 +1438,8 @@ LSTM_fit_stats <- function(pooled_panel, timeSlices, loss_function, batch_size, 
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     


### PR DESCRIPTION
💡 **What:** Replaced raw `cat(".")` and `cat("\n")` calls in neural network epoch callback functions with `message(".", appendLF = FALSE)` and `message("")`.
🎯 **Why:** To improve codebase maturity. `message()` provides a standard diagnostic output stream (stderr) that users can easily suppress or intercept, whereas `cat()` writes directly to standard output (stdout), which is considered informal for package/diagnostic logging.
📊 **Scope:** Modified six `.Rmd` files in `R/empirical/` and `R/simulation/` containing custom keras callbacks.
✅ **Verification:** Verified by checking git diff to ensure valid replacements were made. (Standard R `parse()` checks failed due to duplicated chunk names in the project).

---
*PR created automatically by Jules for task [6968049763844378614](https://jules.google.com/task/6968049763844378614) started by @zeyuz35*