### PR TITLE
🗃️ Curator: [fix list-column initialization for type stability]

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-16 - Prevent Silent Data Flattening in List-Columns
+**Learning:** In R, explicitly initializing list-columns in a dataframe using `target = I(vector("list", N))` and assigning elements via `[[i]]` prevents the silent type coercion and data flattening that occurs when assigning lists to scalar vectors (e.g., `target = c(1:N)` and `df$target[i] <- list(...)`).
+**Action:** Use `I(vector("list", length))` within `data.frame()` and `[[i]]` assignment to guarantee list structure preservation during iterative assignment, particularly before JSON serialization.

--- a/R/AWS/json.Rmd
+++ b/R/AWS/json.Rmd
@@ -34,13 +34,13 @@ dummy_data %>%
 stock_id <- pooled_panel$stock %>%
   unique()
 
-pooled_panel_json <- data.frame(start = c(1:200), target = c(1:200), dynamic_feat = c(1:200))
+pooled_panel_json <- data.frame(start = c(1:200), target = I(vector("list", 200)), dynamic_feat = I(vector("list", 200)))
 
 for (i in 1:200) {
   pooled_panel_filter <- pooled_panel %>%
     filter(stock == stock_id[i])
   
-  pooled_panel_json$target[i] <- list(pooled_panel_filter$rt)
+  pooled_panel_json$target[[i]] <- pooled_panel_filter$rt
   
   pooled_panel_filter_feature <- pooled_panel_filter %>%
     select(-time, -rt, -stock) %>%
@@ -49,7 +49,7 @@ for (i in 1:200) {
     # Transpose it to get the right format of one feature series per row
     t()
   
-  pooled_panel_json[i, ]$dynamic_feat <- pooled_panel_filter_feature %>% list()
+  pooled_panel_json$dynamic_feat[[i]] <- pooled_panel_filter_feature
 }
 
 ## Function that takes data frame in tidy format, and outputs a dataframe 
@@ -64,14 +64,14 @@ tidy_to_json <- function(data) {
   
   ## JUst setting the beginning time to something arbitrary for now, change if needed
   pooled_panel_json <- data.frame(start = rep("2000-01-01 00:00:00", cross_units), 
-                                  target = c(1:cross_units), 
-                                  dynamic_feat = c(1:cross_units))
+                                  target = I(vector("list", cross_units)),
+                                  dynamic_feat = I(vector("list", cross_units)))
   
   for (i in 1:cross_units) {
     pooled_panel_filter <- data %>%
       filter(stock == stock_id[i])
     
-    pooled_panel_json$target[i] <- list(pooled_panel_filter$rt)
+    pooled_panel_json$target[[i]] <- pooled_panel_filter$rt
     
     pooled_panel_filter_feature <- pooled_panel_filter %>%
       select(-time, -rt, -stock) %>%
@@ -80,7 +80,7 @@ tidy_to_json <- function(data) {
       # Transpose it to get the right format of one feature series per row
       t()
     
-    pooled_panel_json[i, ]$dynamic_feat <- pooled_panel_filter_feature %>% list()
+    pooled_panel_json$dynamic_feat[[i]] <- pooled_panel_filter_feature
   }
   
   pooled_panel_json

--- a/R/AWS/sagemaker.R
+++ b/R/AWS/sagemaker.R
@@ -158,8 +158,8 @@ tidy_to_json <- function(data, start) {
   
   ## JUst setting the beginning time to something arbitrary for now, change if needed
   pooled_panel_json <- data.frame(start = rep(start, cross_units), 
-                                  target = c(1:cross_units), 
-                                  dynamic_feat = c(1:cross_units))
+                                  target = I(vector("list", cross_units)),
+                                  dynamic_feat = I(vector("list", cross_units)))
   
   pooled_panel_json <- foreach(i = 1:cross_units, .combine = "rbind") %dopar% {
     df <- data.frame(start = 0, target = 0, dynamic_feat = 0)
@@ -324,8 +324,8 @@ tidy_to_batch_inf <- function(data, start, timeSlices, set) {
   
   ## Just setting the beginning time to something arbitrary for now, change if needed
   pooled_panel_json <- data.frame(start = rep(start, cross_units), 
-                                  target = c(1:cross_units), 
-                                  dynamic_feat = c(1:cross_units))
+                                  target = I(vector("list", cross_units)),
+                                  dynamic_feat = I(vector("list", cross_units)))
   
   for (i in 1:cross_units) {
     pooled_panel_filter <- data %>%
@@ -334,7 +334,7 @@ tidy_to_batch_inf <- function(data, start, timeSlices, set) {
     pooled_panel_filter_rt <- pooled_panel_filter %>%
       filter(time %in% timeSlices[[set]]$train | time %in% timeSlices[[set]]$validation)
     
-    pooled_panel_json$target[i] <- list(pooled_panel_filter_rt$rt)
+    pooled_panel_json$target[[i]] <- pooled_panel_filter_rt$rt
     
     pooled_panel_filter_feature <- pooled_panel_filter %>%
       filter(time %in% timeSlices[[set]]$train | time %in% timeSlices[[set]]$validation | time %in% timeSlices[[set]]$test) %>%
@@ -344,7 +344,7 @@ tidy_to_batch_inf <- function(data, start, timeSlices, set) {
       # Transpose it to get the right format of one feature series per row
       t()
     
-    pooled_panel_json[i, ]$dynamic_feat <- list(pooled_panel_filter_feature)
+    pooled_panel_json$dynamic_feat[[i]] <- pooled_panel_filter_feature
   }
   pooled_panel_json
 }

--- a/R/AWS/sagemaker_run.R
+++ b/R/AWS/sagemaker_run.R
@@ -133,14 +133,14 @@ tidy_to_json <- function(data, start) {
   
   ## JUst setting the beginning time to something arbitrary for now, change if needed
   pooled_panel_json <- data.frame(start = rep(start, cross_units), 
-                                  target = c(1:cross_units), 
-                                  dynamic_feat = c(1:cross_units))
+                                  target = I(vector("list", cross_units)),
+                                  dynamic_feat = I(vector("list", cross_units)))
   
   for (i in 1:cross_units) {
     pooled_panel_filter <- data %>%
       filter(stock == stock_id[i])
     
-    pooled_panel_json$target[i] <- list(pooled_panel_filter$rt)
+    pooled_panel_json$target[[i]] <- pooled_panel_filter$rt
     
     pooled_panel_filter_feature <- pooled_panel_filter %>%
       select(-time, -rt, -stock) %>%
@@ -149,7 +149,7 @@ tidy_to_json <- function(data, start) {
       # Transpose it to get the right format of one feature series per row
       t()
     
-    pooled_panel_json[i, ]$dynamic_feat <- pooled_panel_filter_feature %>% list()
+    pooled_panel_json$dynamic_feat[[i]] <- pooled_panel_filter_feature
   }
   pooled_panel_json
 }
@@ -350,8 +350,8 @@ tidy_to_batch_inf <- function(data, start, timeSlices, set) {
   
   ## Just setting the beginning time to something arbitrary for now, change if needed
   pooled_panel_json <- data.frame(start = rep(start, cross_units), 
-                                  target = c(1:cross_units), 
-                                  dynamic_feat = c(1:cross_units))
+                                  target = I(vector("list", cross_units)),
+                                  dynamic_feat = I(vector("list", cross_units)))
   
   for (i in 1:cross_units) {
     pooled_panel_filter <- data %>%
@@ -370,7 +370,7 @@ tidy_to_batch_inf <- function(data, start, timeSlices, set) {
       # Transpose it to get the right format of one feature series per row
       t()
     
-    pooled_panel_json[i, ]$dynamic_feat <- pooled_panel_filter_feature %>% list()
+    pooled_panel_json$dynamic_feat[[i]] <- pooled_panel_filter_feature
   }
   pooled_panel_json
 }

--- a/R/aws_prep.Rmd
+++ b/R/aws_prep.Rmd
@@ -66,14 +66,14 @@ tidy_to_json <- function(data) {
   
   ## JUst setting the beginning time to something arbitrary for now, change if needed
   pooled_panel_json <- data.frame(start = rep("2000-01-01 00:00:00", cross_units), 
-                                  target = c(1:cross_units), 
-                                  dynamic_feat = c(1:cross_units))
+                                  target = I(vector("list", cross_units)),
+                                  dynamic_feat = I(vector("list", cross_units)))
   
   for (i in 1:cross_units) {
     pooled_panel_filter <- data %>%
       filter(stock == stock_id[i])
     
-    pooled_panel_json$target[i] <- list(pooled_panel_filter$rt)
+    pooled_panel_json$target[[i]] <- pooled_panel_filter$rt
     
     pooled_panel_filter_feature <- pooled_panel_filter %>%
       select(-time, -rt, -stock) %>%
@@ -82,7 +82,7 @@ tidy_to_json <- function(data) {
       # Transpose it to get the right format of one feature series per row
       t()
     
-    pooled_panel_json[i, ]$dynamic_feat <- pooled_panel_filter_feature %>% list()
+    pooled_panel_json$dynamic_feat[[i]] <- pooled_panel_filter_feature
   }
   
   pooled_panel_json


### PR DESCRIPTION
💡 What: Replaced implicit list assignments with explicit vector("list", length) initialization and [[i]] assignment in AWS data prep scripts. 🎯 Why: Assigning a list() to a single element of an atomic numeric vector causes silent type coercion and data flattening in R. 📊 Scope: Updated R/AWS/json.Rmd, R/AWS/sagemaker.R, R/AWS/sagemaker_run.R, and R/aws_prep.Rmd. ✅ Verification: Verified via static syntax checks.

---
*PR created automatically by Jules for task [13596421261838626900](https://jules.google.com/task/13596421261838626900) started by @zeyuz35*