### PR TITLE
⚙️ Modernizer: Native pipes update

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,1 +1,4 @@
 ## Modernizer Journal
+## 2024-05-24 - [Native Pipes Update]
+**Learning:** Native R pipes ( |> ) can directly replace magrittr pipes ( %>% ) when the right-hand side is a function call, reducing external dependency reliance.
+**Action:** Prioritize using base R |> instead of %>% for future pipeline transformations.

--- a/R/AWS/sagemaker_demo.R
+++ b/R/AWS/sagemaker_demo.R
@@ -21,24 +21,24 @@ ggplot(abalone, aes(x = height, y = rings, color = sex)) + geom_point() + geom_j
 
 ## Cleaning
 
-abalone <- abalone %>%
+abalone <- abalone |>
   filter(height != 0)
 
-abalone <- abalone %>%
+abalone <- abalone |>
   mutate(female = as.integer(ifelse(sex == 'F', 1, 0)),
          male = as.integer(ifelse(sex == 'M', 1, 0)),
-         infant = as.integer(ifelse(sex == 'I', 1, 0))) %>%
+         infant = as.integer(ifelse(sex == 'I', 1, 0))) |>
   select(-sex)
-abalone <- abalone %>%
+abalone <- abalone |>
   select(rings:infant, length:shell_weight)
 head(abalone)
 
 ## Train/test split
 
-abalone_train <- abalone %>%
+abalone_train <- abalone |>
   sample_frac(size = 0.7)
 abalone <- anti_join(abalone, abalone_train)
-abalone_test <- abalone %>%
+abalone_test <- abalone |>
   sample_frac(size = 0.5)
 abalone_valid <- anti_join(abalone, abalone_test)
 


### PR DESCRIPTION
💡 What: Replaced all legacy magrittr pipes (`%>%`) with native R pipes (`|>`) in `R/AWS/sagemaker_demo.R`.
🎯 Why: Native pipes are now built into base R, eliminating the need to rely on the `magrittr` package or `tidyverse` for pipeline syntax. This reduces dependencies and improves native execution performance.
📊 Impact: Updated 6 pipeline operations to native syntax, preserving all existing functionality and data transformations.
✅ Verification: Performed static syntax checking using `parse()` since `R/AWS/sagemaker_demo.R` is an exploratory script that cannot be executed without AWS side effects.

---
*PR created automatically by Jules for task [3661534214266177800](https://jules.google.com/task/3661534214266177800) started by @zeyuz35*