### PR TITLE
⚡ Bolt: Resolve O(N^2) rbind performance bottleneck in bind_rt_predictor

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Optimized bind_rt_predictor
+**Learning:** Found O(N^2) 'growing objects' performance bottleneck caused by iterative `rbind()` inside a `for` loop in `R/simulation/Simulation.Rmd` inside `bind_rt_predictor`.
+**Action:** Replaced the `for` loop with `lapply` list accumulation followed by `do.call(rbind, df_list)`. This prevents redundant object reallocation.

--- a/R/simulation/Simulation.Rmd
+++ b/R/simulation/Simulation.Rmd
@@ -1034,19 +1034,13 @@ gen_predictor_z_twoway <- function(C, x){
 # Bind Returns and Predictor Sets Together into one 2D dataframe, ready to be used for training models
 
 bind_rt_predictor <- function(rt_panel, z_panel) {
-  
-  df <- cbind(data.frame(rt_panel[, , 1]), time = 2, stock = paste0("stock_", c(1:N)), data.frame(z_panel[, , 1]))
-
-  colnames(df)[1] <- "rt"
-  row.names(df) <- NULL
-  
-  for (t in 2:Time) {
+  df_list <- lapply(1:Time, function(t) {
     df_new <- cbind(data.frame(rt_panel[, , t]), time = 1+t, stock = paste0("stock_", c(1:N)), data.frame(z_panel[, , t]))
     colnames(df_new)[1] <- "rt"
     row.names(df_new) <- NULL
-    df <- rbind(df, df_new)
-  }
-  return(df)
+    df_new
+  })
+  return(do.call(rbind, df_list))
 }
 
 #test


### PR DESCRIPTION
Replaced an iterative `rbind` in `bind_rt_predictor` (`R/simulation/Simulation.Rmd`) with `lapply` list accumulation and `do.call(rbind, df_list)` to significantly improve simulation speed by avoiding repeated memory reallocations.

---
*PR created automatically by Jules for task [14554800418454864681](https://jules.google.com/task/14554800418454864681) started by @zeyuz35*