### PR TITLE
⚙️ Modernizer: Replace O(N^2) rbind loops with lapply and do.call

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,1 +1,4 @@
 ## Modernizer Journal
+## 2024-05-20 - Replace O(N^2) rbind loops with lapply and do.call
+**Learning:** In R, iteratively calling `rbind()` inside a `for` loop causes an O(N^2) memory reallocation penalty, severely degrading performance for large lists of tuning results.
+**Action:** Replace `for` loop `rbind` operations with `lapply()` list accumulation followed by a single `do.call(rbind, ...)` for optimal memory efficiency and speed while maintaining clarity.

--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -815,11 +815,10 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  ELN_tune_list <- lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -956,10 +955,10 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_list <- lapply(seq_along(RF_model_grid), function(i) {
+    RF_model_grid[[i]]$RF_grid
+  })
+  RF_tune_grid <- do.call(rbind, RF_tune_list)
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/ff_factors/Real Data.Rmd
+++ b/R/empirical_robustness/ff_factors/Real Data.Rmd
@@ -868,11 +868,10 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  ELN_tune_list <- lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -1009,10 +1008,10 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_list <- lapply(seq_along(RF_model_grid), function(i) {
+    RF_model_grid[[i]]$RF_grid
+  })
+  RF_tune_grid <- do.call(rbind, RF_tune_list)
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/missing_threshold/Real Data.Rmd
+++ b/R/empirical_robustness/missing_threshold/Real Data.Rmd
@@ -816,11 +816,10 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  ELN_tune_list <- lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -957,10 +956,10 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_list <- lapply(seq_along(RF_model_grid), function(i) {
+    RF_model_grid[[i]]$RF_grid
+  })
+  RF_tune_grid <- do.call(rbind, RF_tune_list)
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/train_valid_1/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_1/Real Data.Rmd
@@ -813,11 +813,10 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  ELN_tune_list <- lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -954,10 +953,10 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_list <- lapply(seq_along(RF_model_grid), function(i) {
+    RF_model_grid[[i]]$RF_grid
+  })
+  RF_tune_grid <- do.call(rbind, RF_tune_list)
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/train_valid_2/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_2/Real Data.Rmd
@@ -818,11 +818,10 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  ELN_tune_list <- lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -961,10 +960,10 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_list <- lapply(seq_along(RF_model_grid), function(i) {
+    RF_model_grid[[i]]$RF_grid
+  })
+  RF_tune_grid <- do.call(rbind, RF_tune_list)
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -453,11 +453,10 @@ ELN_model_grid <- function(ELN_grid, train_x, train_y, validation_x, validation_
 }
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  ELN_tune_list <- lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -582,11 +581,10 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  ELN_tune_list <- lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -801,10 +799,10 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_list <- lapply(seq_along(RF_model_grid), function(i) {
+    RF_model_grid[[i]]$RF_grid
+  })
+  RF_tune_grid <- do.call(rbind, RF_tune_list)
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 


### PR DESCRIPTION
This PR modernizes the codebase by replacing inefficient `rbind()` calls inside `for` loops with `lapply()` list accumulation followed by `do.call(rbind, ...)`. This resolves the O(N^2) memory reallocation penalty associated with growing data frames iteratively in R, significantly improving performance and maintainability while preserving clarity. Updated `.jules/modernizer.md` with the learning.

---
*PR created automatically by Jules for task [10020990118635934620](https://jules.google.com/task/10020990118635934620) started by @zeyuz35*