### PR TITLE
🗃️ Curator: Fix silent type coercion in R data.frame list-columns

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Fix silent type coercion in R data.frame list-columns
+**Learning:** Assigning a `list()` to a single element of an atomic vector (e.g., initialized as `c(1:N)`) within a data frame causes silent type coercion and flattened data.
+**Action:** Always wrap list-column initializations in `I(vector("list", N))` within `data.frame()` calls, and use double brackets `[[i]]` for iterative list assignment.

--- a/R/aws_prep.Rmd
+++ b/R/aws_prep.Rmd
@@ -66,14 +66,14 @@ tidy_to_json <- function(data) {
   
   ## JUst setting the beginning time to something arbitrary for now, change if needed
   pooled_panel_json <- data.frame(start = rep("2000-01-01 00:00:00", cross_units), 
-                                  target = c(1:cross_units), 
-                                  dynamic_feat = c(1:cross_units))
+                                  target = I(vector("list", cross_units)),
+                                  dynamic_feat = I(vector("list", cross_units)))
   
   for (i in 1:cross_units) {
     pooled_panel_filter <- data %>%
       filter(stock == stock_id[i])
     
-    pooled_panel_json$target[i] <- list(pooled_panel_filter$rt)
+    pooled_panel_json$target[[i]] <- pooled_panel_filter$rt
     
     pooled_panel_filter_feature <- pooled_panel_filter %>%
       select(-time, -rt, -stock) %>%
@@ -82,7 +82,7 @@ tidy_to_json <- function(data) {
       # Transpose it to get the right format of one feature series per row
       t()
     
-    pooled_panel_json[i, ]$dynamic_feat <- pooled_panel_filter_feature %>% list()
+    pooled_panel_json$dynamic_feat[[i]] <- pooled_panel_filter_feature
   }
   
   pooled_panel_json


### PR DESCRIPTION
Fixes silent type coercion and data flattening in R data frames by correctly initializing list-columns using I() and double bracket assignment.

---
*PR created automatically by Jules for task [6032106217554022724](https://jules.google.com/task/6032106217554022724) started by @zeyuz35*