### PR TITLE
⚙️ Modernizer: Optimize iterative rbind with lapply and do.call

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,1 +1,6 @@
 ## Modernizer Journal
+## 2024-05-24 - Optimize Iterative rbind in R
+
+**Learning:** An extremely common but inefficient pattern in legacy R code is to iteratively grow a data frame or list using `df <- rbind(df, new_row)` inside a `for` loop. This results in $O(N^2)$ memory reallocation, heavily bottlenecking performance on large loops. This repository relied on it heavily in tuning functions like `get_ELN_best_tune` and `get_RF_best_tune`.
+
+**Action:** Replace `for` loops containing an iterative `rbind` with a list accumulation using `lapply` (or `mclapply`/`future_lapply` if parallel) and merge the final list of results outside the loop exactly once using `do.call(rbind, list_name)`. This provides significant performance benefits without sacrificing the structure or readability. When applying mass replacements using Python regex tools, target specific functions (e.g. `get_ELN_best_tune`) and strictly verify the file content differences to ensure safety.

--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -815,11 +815,11 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  # Modernized: Replaced O(N^2) iterative rbind with lapply and do.call for improved performance
+  ELN_tune_list <- lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -956,10 +956,11 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  # Modernized: Replaced O(N^2) iterative rbind with lapply and do.call for improved performance
+  RF_tune_list <- lapply(seq_along(RF_model_grid), function(i) {
+    RF_model_grid[[i]]$RF_grid
+  })
+  RF_tune_grid <- do.call(rbind, RF_tune_list)
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/ff_factors/Real Data.Rmd
+++ b/R/empirical_robustness/ff_factors/Real Data.Rmd
@@ -868,11 +868,11 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  # Modernized: Replaced O(N^2) iterative rbind with lapply and do.call for improved performance
+  ELN_tune_list <- lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -1009,10 +1009,11 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  # Modernized: Replaced O(N^2) iterative rbind with lapply and do.call for improved performance
+  RF_tune_list <- lapply(seq_along(RF_model_grid), function(i) {
+    RF_model_grid[[i]]$RF_grid
+  })
+  RF_tune_grid <- do.call(rbind, RF_tune_list)
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/missing_threshold/Real Data.Rmd
+++ b/R/empirical_robustness/missing_threshold/Real Data.Rmd
@@ -816,11 +816,11 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  # Modernized: Replaced O(N^2) iterative rbind with lapply and do.call for improved performance
+  ELN_tune_list <- lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -957,10 +957,11 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  # Modernized: Replaced O(N^2) iterative rbind with lapply and do.call for improved performance
+  RF_tune_list <- lapply(seq_along(RF_model_grid), function(i) {
+    RF_model_grid[[i]]$RF_grid
+  })
+  RF_tune_grid <- do.call(rbind, RF_tune_list)
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/train_valid_1/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_1/Real Data.Rmd
@@ -813,11 +813,11 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  # Modernized: Replaced O(N^2) iterative rbind with lapply and do.call for improved performance
+  ELN_tune_list <- lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -954,10 +954,11 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  # Modernized: Replaced O(N^2) iterative rbind with lapply and do.call for improved performance
+  RF_tune_list <- lapply(seq_along(RF_model_grid), function(i) {
+    RF_model_grid[[i]]$RF_grid
+  })
+  RF_tune_grid <- do.call(rbind, RF_tune_list)
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/train_valid_2/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_2/Real Data.Rmd
@@ -818,11 +818,11 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  # Modernized: Replaced O(N^2) iterative rbind with lapply and do.call for improved performance
+  ELN_tune_list <- lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -961,10 +961,11 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  # Modernized: Replaced O(N^2) iterative rbind with lapply and do.call for improved performance
+  RF_tune_list <- lapply(seq_along(RF_model_grid), function(i) {
+    RF_model_grid[[i]]$RF_grid
+  })
+  RF_tune_grid <- do.call(rbind, RF_tune_list)
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -453,11 +453,11 @@ ELN_model_grid <- function(ELN_grid, train_x, train_y, validation_x, validation_
 }
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  # Modernized: Replaced O(N^2) iterative rbind with lapply and do.call for improved performance
+  ELN_tune_list <- lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -582,11 +582,11 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  # Modernized: Replaced O(N^2) iterative rbind with lapply and do.call for improved performance
+  ELN_tune_list <- lapply(seq_along(model_grid), function(i) {
+    cbind(model_grid[[i]]$ELN_grid, list_index = i)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -801,10 +801,11 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  # Modernized: Replaced O(N^2) iterative rbind with lapply and do.call for improved performance
+  RF_tune_list <- lapply(seq_along(RF_model_grid), function(i) {
+    RF_model_grid[[i]]$RF_grid
+  })
+  RF_tune_grid <- do.call(rbind, RF_tune_list)
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 


### PR DESCRIPTION
Replaced O(N^2) iterative rbind() inside for loops with list accumulation (lapply) and do.call(rbind, ...) in get_ELN_best_tune and get_RF_best_tune functions to improve performance and idiomatic R modernization.

---
*PR created automatically by Jules for task [9072123246593365052](https://jules.google.com/task/9072123246593365052) started by @zeyuz35*