### PR TITLE
⚙️ Modernizer: Optimize iterative rbind loops via list accumulation

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,1 +1,3 @@
-## Modernizer Journal
+## 2025-05-23 - [Optimize Iterative Data Frame Binding (rbind) Inside For Loops]
+**Learning:** Legacy R code frequently uses O(N^2) iterative object growing (`rbind` inside `for` loops) for building large data frames. This scales poorly when aggregating models (e.g., in `get_ELN_best_tune`, `get_RF_best_tune`, `bind_rt_predictor`, and similar data aggregation pipelines).
+**Action:** Replace iterative `rbind()` inside `for` loops with list accumulation (e.g., via `lapply()`) followed by a single combined binding step like `do.call(rbind, list)`. This reduces dependency on O(N^2) allocations while retaining readable syntax and correct functionality. Also ensure iterators change from single variables (e.g., `i`) to expressive ones (`grid_ii`) following AGENTS.md conventions.

--- a/R/Gu et al Recreation.Rmd
+++ b/R/Gu et al Recreation.Rmd
@@ -400,11 +400,7 @@ for (t in 1:(Time+1)) {
   rt_cross_tune_list[[t]] <- df
 }
 
-rt_cross_tune_panel <- rt_cross_tune_list[[1]]
-
-for (t in 1:(Time+1)) {
-  rt_cross_tune_panel <- rbind(rt_cross_tune_panel, rt_cross_tune_list[[t]])
-}
+rt_cross_tune_panel <- do.call(rbind, rt_cross_tune_list)
 
 #Remove 1st row because returns data only starts from t = 2
 rt_cross_tune_panel <- rt_cross_tune_panel %>%

--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -815,11 +815,10 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  ELN_tune_list <- lapply(seq_along(model_grid), function(grid_ii) {
+    cbind(model_grid[[grid_ii]]$ELN_grid, list_index = grid_ii)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -956,10 +955,10 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_list <- lapply(seq_along(RF_model_grid), function(grid_ii) {
+    RF_model_grid[[grid_ii]]$RF_grid
+  })
+  RF_tune_grid <- do.call(rbind, RF_tune_list)
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/ff_factors/Real Data.Rmd
+++ b/R/empirical_robustness/ff_factors/Real Data.Rmd
@@ -868,11 +868,10 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  ELN_tune_list <- lapply(seq_along(model_grid), function(grid_ii) {
+    cbind(model_grid[[grid_ii]]$ELN_grid, list_index = grid_ii)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -1009,10 +1008,10 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_list <- lapply(seq_along(RF_model_grid), function(grid_ii) {
+    RF_model_grid[[grid_ii]]$RF_grid
+  })
+  RF_tune_grid <- do.call(rbind, RF_tune_list)
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/missing_threshold/Real Data.Rmd
+++ b/R/empirical_robustness/missing_threshold/Real Data.Rmd
@@ -816,11 +816,10 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  ELN_tune_list <- lapply(seq_along(model_grid), function(grid_ii) {
+    cbind(model_grid[[grid_ii]]$ELN_grid, list_index = grid_ii)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -957,10 +956,10 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_list <- lapply(seq_along(RF_model_grid), function(grid_ii) {
+    RF_model_grid[[grid_ii]]$RF_grid
+  })
+  RF_tune_grid <- do.call(rbind, RF_tune_list)
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/train_valid_1/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_1/Real Data.Rmd
@@ -813,11 +813,10 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  ELN_tune_list <- lapply(seq_along(model_grid), function(grid_ii) {
+    cbind(model_grid[[grid_ii]]$ELN_grid, list_index = grid_ii)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -954,10 +953,10 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_list <- lapply(seq_along(RF_model_grid), function(grid_ii) {
+    RF_model_grid[[grid_ii]]$RF_grid
+  })
+  RF_tune_grid <- do.call(rbind, RF_tune_list)
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/empirical_robustness/train_valid_2/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_2/Real Data.Rmd
@@ -818,11 +818,10 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  ELN_tune_list <- lapply(seq_along(model_grid), function(grid_ii) {
+    cbind(model_grid[[grid_ii]]$ELN_grid, list_index = grid_ii)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -961,10 +960,10 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_list <- lapply(seq_along(RF_model_grid), function(grid_ii) {
+    RF_model_grid[[grid_ii]]$RF_grid
+  })
+  RF_tune_grid <- do.call(rbind, RF_tune_list)
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -453,11 +453,10 @@ ELN_model_grid <- function(ELN_grid, train_x, train_y, validation_x, validation_
 }
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  ELN_tune_list <- lapply(seq_along(model_grid), function(grid_ii) {
+    cbind(model_grid[[grid_ii]]$ELN_grid, list_index = grid_ii)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -582,11 +581,10 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
-  ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
+  ELN_tune_list <- lapply(seq_along(model_grid), function(grid_ii) {
+    cbind(model_grid[[grid_ii]]$ELN_grid, list_index = grid_ii)
+  })
+  ELN_tune_dataframe <- data.frame(do.call(rbind, ELN_tune_list))
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
 
@@ -801,10 +799,10 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
 #Returns the dataframe row containing the "best" hyperparameters
 
 get_RF_best_tune <- function(RF_model_grid) {
-  RF_tune_grid <- RF_model_grid[[1]]$RF_grid
-  for (i in 2:length(RF_model_grid)) {
-    RF_tune_grid <- rbind(RF_tune_grid, RF_model_grid[[i]]$RF_grid)
-  }
+  RF_tune_list <- lapply(seq_along(RF_model_grid), function(grid_ii) {
+    RF_model_grid[[grid_ii]]$RF_grid
+  })
+  RF_tune_grid <- do.call(rbind, RF_tune_list)
   return(RF_tune_grid[which.min(RF_tune_grid$validation_loss), ])
 }
 

--- a/R/simulation/Simulation.Rmd
+++ b/R/simulation/Simulation.Rmd
@@ -1034,18 +1034,13 @@ gen_predictor_z_twoway <- function(C, x){
 # Bind Returns and Predictor Sets Together into one 2D dataframe, ready to be used for training models
 
 bind_rt_predictor <- function(rt_panel, z_panel) {
-  
-  df <- cbind(data.frame(rt_panel[, , 1]), time = 2, stock = paste0("stock_", c(1:N)), data.frame(z_panel[, , 1]))
-
-  colnames(df)[1] <- "rt"
-  row.names(df) <- NULL
-  
-  for (t in 2:Time) {
+  df_list <- lapply(1:Time, function(t) {
     df_new <- cbind(data.frame(rt_panel[, , t]), time = 1+t, stock = paste0("stock_", c(1:N)), data.frame(z_panel[, , t]))
     colnames(df_new)[1] <- "rt"
     row.names(df_new) <- NULL
-    df <- rbind(df, df_new)
-  }
+    df_new
+  })
+  df <- do.call(rbind, df_list)
   return(df)
 }
 


### PR DESCRIPTION
This PR replaces iterative O(N^2) `rbind` calls inside `for` loops with a list accumulation approach using `lapply` followed by `do.call(rbind, list)`. This reduces performance bottlenecks in repetitive data frame concatenations such as `get_ELN_best_tune`, `get_RF_best_tune`, `bind_rt_predictor`, and `rt_cross_tune_panel`. Added findings to `.jules/modernizer.md`.

---
*PR created automatically by Jules for task [8883573467743844464](https://jules.google.com/task/8883573467743844464) started by @zeyuz35*