### PR TITLE
⚙️ Modernizer: Replace for loops with future_lapply in sagemaker_run

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,1 +1,4 @@
 ## Modernizer Journal
+## $(date +'%Y-%m-%d') - Replace base for loops with future.apply
+**Learning:** Initializing data.frame with list columns directly via `I(list(...))` inside `future.apply` or iteratively with base R loops can cause performance bottlenecks and silent type coercion issues. `future_lapply` improves speed and parallelization over the sequential `for` loops that populate JSON structure for DeepAR. Using base subsetting inside `future_lapply` also increases performance by dropping slow `dplyr::filter` calls.
+**Action:** Replace `for` loops in `.R` files that grow lists or dataframes iteratively with `future.apply::future_lapply`. Explicitly capture subsets using base R data.frame subsetting and finally `lapply` over the generated list to populate `data.frame` columns. Use `seq_len()` rather than `1:N` for safer bounds handling.

--- a/R/AWS/sagemaker_run.R
+++ b/R/AWS/sagemaker_run.R
@@ -132,25 +132,22 @@ tidy_to_json <- function(data, start) {
   cross_units <- length(stock_id)
   
   ## JUst setting the beginning time to something arbitrary for now, change if needed
-  pooled_panel_json <- data.frame(start = rep(start, cross_units), 
-                                  target = c(1:cross_units), 
-                                  dynamic_feat = c(1:cross_units))
-  
-  for (i in 1:cross_units) {
-    pooled_panel_filter <- data %>%
-      filter(stock == stock_id[i])
+  res <- future.apply::future_lapply(seq_len(cross_units), function(ii) {
+    pooled_panel_filter <- data[data$stock == stock_id[ii], ]
     
-    pooled_panel_json$target[i] <- list(pooled_panel_filter$rt)
+    target <- pooled_panel_filter$rt
     
-    pooled_panel_filter_feature <- pooled_panel_filter %>%
-      select(-time, -rt, -stock) %>%
-      unname() %>%
-      as.matrix() %>%
-      # Transpose it to get the right format of one feature series per row
-      t()
+    dynamic_feat <- as.matrix(unname(pooled_panel_filter[, !names(pooled_panel_filter) %in% c("time", "rt", "stock"), drop = FALSE]))
+    dynamic_feat <- t(dynamic_feat)
+    dimnames(dynamic_feat) <- list(NULL, NULL)
     
-    pooled_panel_json[i, ]$dynamic_feat <- pooled_panel_filter_feature %>% list()
-  }
+    list(target = target, dynamic_feat = dynamic_feat)
+  })
+
+  pooled_panel_json <- data.frame(start = rep(start, cross_units))
+  pooled_panel_json$target <- lapply(res, `[[`, "target")
+  pooled_panel_json$dynamic_feat <- lapply(res, `[[`, "dynamic_feat")
+
   pooled_panel_json
 }
 
@@ -349,29 +346,24 @@ tidy_to_batch_inf <- function(data, start, timeSlices, set) {
   cross_units <- length(stock_id)
   
   ## Just setting the beginning time to something arbitrary for now, change if needed
-  pooled_panel_json <- data.frame(start = rep(start, cross_units), 
-                                  target = c(1:cross_units), 
-                                  dynamic_feat = c(1:cross_units))
-  
-  for (i in 1:cross_units) {
-    pooled_panel_filter <- data %>%
-      filter(stock == stock_id[i])
-      
-    pooled_panel_json$target[i] <- pooled_panel_filter %>%
-      filter(time %in% timeSlices[[set]]$train | time %in% timeSlices[[set]]$validation) %>%
-      dplyr::select(rt) %>%
-      list()
+  res <- future.apply::future_lapply(seq_len(cross_units), function(ii) {
+    pooled_panel_filter <- data[data$stock == stock_id[ii], ]
     
-    pooled_panel_filter_feature <- pooled_panel_filter %>%
-      filter(time %in% timeSlices[[set]]$train | time %in% timeSlices[[set]]$validation | time %in% timeSlices[[set]]$test) %>%
-      dplyr::select(-time, -rt, -stock) %>%
-      unname() %>%
-      as.matrix() %>%
-      # Transpose it to get the right format of one feature series per row
-      t()
+    target_filter <- pooled_panel_filter[pooled_panel_filter$time %in% timeSlices[[set]]$train | pooled_panel_filter$time %in% timeSlices[[set]]$validation, ]
+    target <- target_filter$rt
     
-    pooled_panel_json[i, ]$dynamic_feat <- pooled_panel_filter_feature %>% list()
-  }
+    feat_filter <- pooled_panel_filter[pooled_panel_filter$time %in% timeSlices[[set]]$train | pooled_panel_filter$time %in% timeSlices[[set]]$validation | pooled_panel_filter$time %in% timeSlices[[set]]$test, ]
+    dynamic_feat <- as.matrix(unname(feat_filter[, !names(feat_filter) %in% c("time", "rt", "stock"), drop = FALSE]))
+    dynamic_feat <- t(dynamic_feat)
+    dimnames(dynamic_feat) <- list(NULL, NULL)
+
+    list(target = target, dynamic_feat = dynamic_feat)
+  })
+
+  pooled_panel_json <- data.frame(start = rep(start, cross_units))
+  pooled_panel_json$target <- lapply(res, `[[`, "target")
+  pooled_panel_json$dynamic_feat <- lapply(res, `[[`, "dynamic_feat")
+
   pooled_panel_json
 }
 


### PR DESCRIPTION
Replaced standard O(N^2) list-column appending for loops with optimized future_lapply patterns to modernize the execution flow per AGENTS.md

---
*PR created automatically by Jules for task [16786229613686288200](https://jules.google.com/task/16786229613686288200) started by @zeyuz35*