### PR TITLE
📝 Docent: convert raw cat() to message()

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - convert raw cat() to message()
+**Learning:** Raw output with `cat()` should be formatted into structured `message()` in R.
+**Action:** Replace `cat()` calls with `message()` ensuring multiple string arguments are passed via `paste0()` and formatting explicitly avoids trailing `\n`.

--- a/R/xgboost/demo/predict_first_ntree.R
+++ b/R/xgboost/demo/predict_first_ntree.R
@@ -11,7 +11,7 @@ nrounds = 2
 
 # training the model for two rounds
 bst = xgb.train(param, dtrain, nrounds, nthread = 2, watchlist)
-cat('start testing prediction from first n trees\n')
+message('start testing prediction from first n trees')
 labels <- getinfo(dtest,'label')
 
 ### predict using first 1 tree
@@ -19,5 +19,5 @@ ypred1 = predict(bst, dtest, ntreelimit=1)
 # by default, we predict using all the trees
 ypred2 = predict(bst, dtest)
 
-cat('error of ypred1=', mean(as.numeric(ypred1>0.5)!=labels),'\n')
-cat('error of ypred2=', mean(as.numeric(ypred2>0.5)!=labels),'\n')
+message(paste0('error of ypred1=', mean(as.numeric(ypred1>0.5)!=labels)))
+message(paste0('error of ypred2=', mean(as.numeric(ypred2>0.5)!=labels)))


### PR DESCRIPTION
Converted raw `cat()` output to structured `message()` logging to ensure professional communication standards.

---
*PR created automatically by Jules for task [12793568897880059299](https://jules.google.com/task/12793568897880059299) started by @zeyuz35*