### PR TITLE
⚡ Bolt: Replace dplyr::filter with base R subsetting in R loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2024-05-13 - Performance Improvements
+
+**Learning:** Use of `dplyr::filter` in `for` loops on large dataframes creates performance bottlenecks compared to base R subsetting or functional methods.
+
+**Action:** Replace `dplyr::filter` with base R vectorised subsetting in loop iterators to increase performance, specifically when iterating over distinct groups or slicing multiple times.

--- a/R/Gu et al Recreation.Rmd
+++ b/R/Gu et al Recreation.Rmd
@@ -422,9 +422,8 @@ rt_id_tune_df <- data.frame(
   rsquare = c(1:N)
 )
 
-for (i in 1:N) {
-  rt_id_tune_panel <- rt_cross_tune_panel %>%
-    filter(stock == i)
+for (i in seq_len(N)) {
+  rt_id_tune_panel <- rt_cross_tune_panel[rt_cross_tune_panel$stock == i, ]
   rt_id_tune_df$rsquare[i] <- r_squared_proper(rt_id_tune_panel$g, rt_id_tune_panel$return)
 }
 
@@ -441,9 +440,8 @@ vol_tune_df <- data.frame(
   annual_vol = c(1:N)
 )
 
-for (i in 1:N) {
-  vol_tune_panel <- rt_cross_tune_panel %>%
-    filter(stock == i)
+for (i in seq_len(N)) {
+  vol_tune_panel <- rt_cross_tune_panel[rt_cross_tune_panel$stock == i, ]
   vol_tune_df$annual_vol[i] <- sd(vol_tune_panel$return) * sqrt(12)
 }
 
@@ -464,8 +462,7 @@ rt_cross_section <- data.frame(
 for (t in 2:(Time+1)) {
   rt_cross_section$time <- t
   
-  rt_cross_tune_panel_cross_section <- rt_cross_tune_panel %>% 
-    filter(time == t)
+  rt_cross_tune_panel_cross_section <- rt_cross_tune_panel[rt_cross_tune_panel$time == t, ]
   
   rt_cross_section$rsquare[t-1] <- r_squared_proper(rt_cross_tune_panel_cross_section$g, rt_cross_tune_panel_cross_section$return)
 }


### PR DESCRIPTION
Replaced `dplyr::filter` with faster base R vectorised subsetting in loop iterators to increase performance

---
*PR created automatically by Jules for task [7708037907628344094](https://jules.google.com/task/7708037907628344094) started by @zeyuz35*