### PR TITLE
🗃️ Curator: Fix silent type coercion in dataframe list-columns

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Fix silent type coercion in dataframe list-column initialization
+**Learning:** Initializing data frame columns as atomic numeric vectors (e.g., `target = 1:N`) and then attempting to assign lists to individual elements using single brackets (e.g., `df$target[i] <- list(val)`) causes silent type coercion and potential data flattening in R.
+**Action:** Use `I(vector("list", N))` to safely initialize list-columns within a `data.frame()` call. When assigning elements to these columns iteratively, use double brackets (`df$target[[i]] <- val`) and remove the `list()` wrapper around the value to prevent unintended nested list structures.

--- a/R/aws_prep.Rmd
+++ b/R/aws_prep.Rmd
@@ -66,14 +66,14 @@ tidy_to_json <- function(data) {
   
   ## JUst setting the beginning time to something arbitrary for now, change if needed
   pooled_panel_json <- data.frame(start = rep("2000-01-01 00:00:00", cross_units), 
-                                  target = c(1:cross_units), 
-                                  dynamic_feat = c(1:cross_units))
+                                  target = I(vector("list", cross_units)),
+                                  dynamic_feat = I(vector("list", cross_units)))
   
   for (i in 1:cross_units) {
     pooled_panel_filter <- data %>%
       filter(stock == stock_id[i])
     
-    pooled_panel_json$target[i] <- list(pooled_panel_filter$rt)
+    pooled_panel_json$target[[i]] <- pooled_panel_filter$rt
     
     pooled_panel_filter_feature <- pooled_panel_filter %>%
       select(-time, -rt, -stock) %>%
@@ -82,7 +82,7 @@ tidy_to_json <- function(data) {
       # Transpose it to get the right format of one feature series per row
       t()
     
-    pooled_panel_json[i, ]$dynamic_feat <- pooled_panel_filter_feature %>% list()
+    pooled_panel_json$dynamic_feat[[i]] <- pooled_panel_filter_feature
   }
   
   pooled_panel_json


### PR DESCRIPTION
Updates the initialization of target and dynamic_feat columns in tidy_to_json to use I(vector('list', cross_units)) instead of atomic numeric vectors, preventing silent type coercion when assigning lists.

---
*PR created automatically by Jules for task [8081453290194215627](https://jules.google.com/task/8081453290194215627) started by @zeyuz35*