### PR TITLE
⚡ Bolt: Optimize loop subsetting with base R

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-01-28 - Optimize loop subsetting in empirical robustness scripts
+**Learning:** Using `dplyr::filter` inside `foreach` loops on large datasets adds significant overhead due to S3 dispatch, evaluation logic, and dataframe creation for each iteration. Base R logical subsetting `dataset[dataset$time == time_periods[t], ]` is considerably faster for single-condition row subsetting within iterative constructs.
+**Action:** Replace `%>% filter(...)` with base R logical subsetting `[...]` in tight loop iterations across analysis scripts.

--- a/R/empirical_robustness/ff_factors/Real Data.Rmd
+++ b/R/empirical_robustness/ff_factors/Real Data.Rmd
@@ -235,8 +235,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
     
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     # Mean Case
     if (impute_type == "mean") {
@@ -269,8 +268,7 @@ impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
   imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     if (impute_type == "median") {
       # Impute the median for ALL columns
@@ -309,8 +307,7 @@ cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
   normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     dataset_cross_section_y <- dataset_cross_section %>%
       dplyr::select(time, stock, rt)
@@ -689,8 +686,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(lm_model, newdata = test_cross_section)
     
@@ -708,8 +704,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
 
     test_cross_section_x <- as.matrix(test_cross_section[4:ncol(test_cross_section)])
     
@@ -730,8 +725,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(rf_model, newdata = test_cross_section)$predicted
     
@@ -749,8 +743,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     test_cross_section_x <- test_cross_section[4:ncol(test_cross_section)]
     

--- a/R/empirical_robustness/missing_threshold/Real Data.Rmd
+++ b/R/empirical_robustness/missing_threshold/Real Data.Rmd
@@ -228,8 +228,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
     
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     # Mean Case
     if (impute_type == "mean") {
@@ -262,8 +261,7 @@ impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
   imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     if (impute_type == "median") {
       # Impute the median for ALL columns
@@ -302,8 +300,7 @@ cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
   normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     dataset_cross_section_y <- dataset_cross_section %>%
       dplyr::select(time, stock, rt)
@@ -635,8 +632,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(lm_model, newdata = test_cross_section)
     
@@ -654,8 +650,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
 
     test_cross_section_x <- as.matrix(test_cross_section[4:ncol(test_cross_section)])
     
@@ -676,8 +671,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(rf_model, newdata = test_cross_section)$predicted
     
@@ -695,8 +689,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     test_cross_section_x <- test_cross_section[4:ncol(test_cross_section)]
     

--- a/R/empirical_robustness/train_valid_1/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_1/Real Data.Rmd
@@ -226,8 +226,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
     
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     # Mean Case
     if (impute_type == "mean") {
@@ -260,8 +259,7 @@ impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
   imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     if (impute_type == "median") {
       # Impute the median for ALL columns
@@ -300,8 +298,7 @@ cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
   normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     dataset_cross_section_y <- dataset_cross_section %>%
       dplyr::select(time, stock, rt)
@@ -633,8 +630,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %dopar% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(lm_model, newdata = test_cross_section)
     
@@ -652,8 +648,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %dopar% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
 
     test_cross_section_x <- as.matrix(test_cross_section[4:ncol(test_cross_section)])
     
@@ -674,8 +669,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(rf_model, newdata = test_cross_section)$predicted
     
@@ -693,8 +687,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     test_cross_section_x <- test_cross_section[4:ncol(test_cross_section)]
     

--- a/R/empirical_robustness/train_valid_2/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_2/Real Data.Rmd
@@ -228,8 +228,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
     
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     # Mean Case
     if (impute_type == "mean") {
@@ -262,8 +261,7 @@ impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
   imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     if (impute_type == "median") {
       # Impute the median for ALL columns
@@ -302,8 +300,7 @@ cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
   normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     dataset_cross_section_y <- dataset_cross_section %>%
       dplyr::select(time, stock, rt)
@@ -635,8 +632,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %dopar% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(lm_model, newdata = test_cross_section)
     
@@ -654,8 +650,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %dopar% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
 
     test_cross_section_x <- as.matrix(test_cross_section[4:ncol(test_cross_section)])
     
@@ -680,8 +675,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(rf_model, newdata = test_cross_section)$predicted
     
@@ -699,8 +693,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     test_cross_section_x <- test_cross_section[4:ncol(test_cross_section)]
     


### PR DESCRIPTION
Replaced `dplyr::filter` with base R logical subsetting within `foreach` loops to optimize memory usage and performance by bypassing S3 dispatch overhead.

---
*PR created automatically by Jules for task [13549019460169851707](https://jules.google.com/task/13549019460169851707) started by @zeyuz35*