### PR TITLE
📝 Docent: convert cat() to message() for diagnostic output

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Convert cat to message
+**Learning:** Found multiple instances where `cat()` was used for informational messages with explicit newlines `\n`, which violates the project's styling agents.
+**Action:** Replaced `cat()` with `message()` and used `paste0()` to concatenate variables, removing explicit `\n` as `message()` appends newlines automatically.

--- a/R/xgboost/demo/predict_first_ntree.R
+++ b/R/xgboost/demo/predict_first_ntree.R
@@ -11,7 +11,7 @@ nrounds = 2
 
 # training the model for two rounds
 bst = xgb.train(param, dtrain, nrounds, nthread = 2, watchlist)
-cat('start testing prediction from first n trees\n')
+message('start testing prediction from first n trees')
 labels <- getinfo(dtest,'label')
 
 ### predict using first 1 tree
@@ -19,5 +19,5 @@ ypred1 = predict(bst, dtest, ntreelimit=1)
 # by default, we predict using all the trees
 ypred2 = predict(bst, dtest)
 
-cat('error of ypred1=', mean(as.numeric(ypred1>0.5)!=labels),'\n')
-cat('error of ypred2=', mean(as.numeric(ypred2>0.5)!=labels),'\n')
+message(paste0('error of ypred1=', mean(as.numeric(ypred1>0.5)!=labels)))
+message(paste0('error of ypred2=', mean(as.numeric(ypred2>0.5)!=labels)))


### PR DESCRIPTION
Converts raw cat() diagnostic outputs to structured base::message() calls in predict_first_ntree.R, complying with the project's style guidelines.

---
*PR created automatically by Jules for task [13381759516411462948](https://jules.google.com/task/13381759516411462948) started by @zeyuz35*