### PR TITLE
⚙️ Modernizer: Update iterator syntax from 1:length() to seq_along()

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,1 +1,4 @@
 ## Modernizer Journal
+## 2024-05-26 - [Modernizer: Iterator Syntax Update]
+**Learning:** Legacy codebase used `1:length(x)` and `1:N` iterators which are unsafe (they can produce `1:0` loops). Modern R prefers `seq_along(x)` or `seq_len(N)`.
+**Action:** Replaced instances of `1:length(x)` and `1:N` iterators with `seq_along()` and `seq_len()` in loops and indices using a targeted string replacement script.

--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -150,7 +150,7 @@ time_df <- data.frame(time = unique(datashare$time)) %>%
 ## This approach keeps a highly variable number of stocks, depending on when you filter the data from
 ## Going with a filter of >= 1993.5 gives us 195 unique stocks, just going with this for now for feasibility
 
-datashare <- foreach(i = (1:length(unique(datashare$stock))), .combine = "rbind") %dopar% {
+datashare <- foreach(i = (seq_along(unique(datashare$stock))), .combine = "rbind") %dopar% {
   datashare_stock <- datashare %>%
     mutate(time = as.numeric(time)) %>%
     filter(stock == unique(datashare$stock)[i]) %>%
@@ -171,7 +171,7 @@ length(unique(datashare$stock))
 ## Sensible, because companies can be bought out and floated again, etc.
 ## Not likely to make a huge difference, but actual quarterly returns are computed, instead of log quarterly returns
 ## This is because stock prices can in some cases have rather large movements over a quarter
-# datashare <- foreach(i = (1:length(unique(datashare$stock))), .combine = rbind) %dopar% {
+# datashare <- foreach(i = (seq_along(unique(datashare$stock))), .combine = rbind) %dopar% {
 #   datashare_stock <- datashare %>%
 #     mutate(time = as.numeric(time)) %>%
 #     filter(stock == unique(datashare$stock)[i]) %>%
@@ -227,7 +227,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   time_periods <- unique(dataset$time)
   
-  cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  cross_sectional_values_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
@@ -262,7 +262,7 @@ colnames(test)[colSums(is.na(test)) > 0]
 impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
-  imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  imputed_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -302,7 +302,7 @@ ncol(datashare_filtered)
 cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
-  normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  normalize_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -420,7 +420,7 @@ write.csv(individual_factor_names, file = "individual_factor_names.csv")
 ## This section builds in the macro dataset and egnerates the interaction terms
 interaction_terms <- rep(list(0), length(macro_factor_names))
 
-for (i in 1:length(macro_factor_names)) {
+for (i in seq_along(macro_factor_names)) {
   interaction_terms[[i]] <- paste(macro_factor_names[i], individual_factor_names, sep = ":", collapse = " + ")
 }
 
@@ -634,7 +634,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -653,7 +653,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -675,7 +675,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -694,7 +694,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -786,7 +786,7 @@ LM_fit <- function(pooled_panel, timeSlices, loss_function, f,
 
 ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validation_y, loss_function, nlamb) {
   
-  ELN_model_grid_list <- foreach(i = (1:length(alpha_grid))) %dopar% {
+  ELN_model_grid_list <- foreach(i = (seq_along(alpha_grid))) %dopar% {
     ELN_model_grid <- list(ELN_grid = 0, model = 0)
     
     #MSE Case

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -211,7 +211,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -230,7 +230,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -252,7 +252,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -271,7 +271,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -553,7 +553,7 @@ alpha_grid <- seq(0, 1, 0.01)
 
 ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validation_y, loss_function, nlamb) {
   
-  ELN_model_grid_list <- foreach(i = (1:length(alpha_grid))) %dopar% {
+  ELN_model_grid_list <- foreach(i = (seq_along(alpha_grid))) %dopar% {
     ELN_model_grid <- list(ELN_grid = 0, model = 0)
     
     #MSE Case

--- a/R/simulation/Simulation.Rmd
+++ b/R/simulation/Simulation.Rmd
@@ -66,7 +66,7 @@ gen_C_bar <- function(rho_a, rho_b){
   #provideDimnames doesn't do exactly what I want it to
   #Just do it manually via paste0
   
-  stock_dim <- paste0("stock_", c(1:N))
+  stock_dim <- paste0("stock_", c(seq_len(N)))
   c_dim <- paste0("c_", c(1:P_c))
   time_dim <- paste0("time_", c(0:(Time+1)))
   
@@ -125,7 +125,7 @@ gen_W <- function(lambda_degree){
 gen_C_hat <- function(C_bar, cross_corr_degree){
   W <- gen_W(cross_corr_degree)
   
-  stock_dim <- paste0("stock_", c(1:N))
+  stock_dim <- paste0("stock_", c(seq_len(N)))
   c_dim <- paste0("c_", c(1:P_c))
   time_dim <- paste0("time_", c(1:(Time+1)))
   
@@ -147,7 +147,7 @@ gen_C_hat <- function(C_bar, cross_corr_degree){
 
 gen_C <- function(C_matrix){
   
-  stock_dim <- paste0("stock_", c(1:N))
+  stock_dim <- paste0("stock_", c(seq_len(N)))
   c_dim <- paste0("c_", c(1:P_c))
   time_dim <- paste0("time_", c(1:(Time+1)))
   
@@ -357,13 +357,13 @@ gen_g_factor_panel <- function(g_function, C, x) {
   #G1 case
   if (g_name == "g1") {
         
-    stock_dim <- paste0("stock_", c(1:N))
+    stock_dim <- paste0("stock_", c(seq_len(N)))
     c_dim <- c("c_i1,t", "c_i2,t", "c_i3,t * x_t'")
     time_dim <- paste0("time_", c(1:(Time)))
         
     g_factor_panel <- array(0, dim = c(N, 3, Time), dimnames = list(stock_dim, c_dim, time_dim))
     
-    for (i in 1:N) {
+    for (i in seq_len(N)) {
       for (t in 1:Time) {
         #Univariate xt Case
         if (nrow(x) == 1) {
@@ -380,13 +380,13 @@ gen_g_factor_panel <- function(g_function, C, x) {
   #G2 Case
   else if (g_name == "g2") {
         
-    stock_dim <- paste0("stock_", c(1:N))
+    stock_dim <- paste0("stock_", c(seq_len(N)))
     c_dim <- c("c_i1,t^2", "c_i1,t * c_i2,t", "sgn(c_i3,t * x_t')")
     time_dim <- paste0("time_", c(1:(Time)))
         
     g_factor_panel <- array(0, dim = c(N, 3, Time), dimnames = list(stock_dim, c_dim, time_dim))
     
-    for (i in 1:N) {
+    for (i in seq_len(N)) {
       for (t in 1:Time) {
         #Univariate xt Case
         if (nrow(x) == 1) {
@@ -408,13 +408,13 @@ gen_g_factor_panel <- function(g_function, C, x) {
   #G3 Case
   else if (g_name == "g3") {
         
-    stock_dim <- paste0("stock_", c(1:N))
+    stock_dim <- paste0("stock_", c(seq_len(N)))
     c_dim <- c("I(c_i3,t > 0)", "c_i2,t^3", "c_i1,t * c_12,t * I(c_i3,t > 0)", "logit(c_i3,t)")
     time_dim <- paste0("time_", c(1:(Time)))
         
     g_factor_panel <- array(0, dim = c(N, 4, Time), dimnames = list(stock_dim, c_dim, time_dim))
     
-    for (i in 1:N) {
+    for (i in seq_len(N)) {
       for (t in 1:Time) {
         g_factor_panel[i, , t] <- matrix(c(
           (C[i, 1, t] > 0), 
@@ -429,7 +429,7 @@ gen_g_factor_panel <- function(g_function, C, x) {
   #G4 Case
   else if (g_name == "g4") {
         
-    stock_dim <- paste0("stock_", c(1:N))
+    stock_dim <- paste0("stock_", c(seq_len(N)))
     c_dim <- c("chat_i1,t", "chat_i2,t", "chat_i3,t * x_t'")
     time_dim <- paste0("time_", c(1:(Time)))
         
@@ -437,7 +437,7 @@ gen_g_factor_panel <- function(g_function, C, x) {
     
     #Same as G1 case, but remember to pass c_hat through to this
     
-    for (i in 1:N) {
+    for (i in seq_len(N)) {
       for (t in 1:Time) {
         #Univariate xt Case
         if (nrow(x) == 1) {
@@ -472,7 +472,7 @@ gen_g_factor_panel <- function(g_function, C, x) {
 #Remmeber to make sure theta and the factor set are conformable
 gen_g_panel <- function(g_factor, theta) {
   g_panel <- array(0, dim = c(N, 1, Time))
-  for (i in 1:N) {
+  for (i in seq_len(N)) {
     for (t in 1:Time) {
       g_panel[i, 1, t] <- g_factor[i, , t] %*% t(theta)
     }
@@ -662,7 +662,7 @@ annual_vol <- matrix(0, N, 1)
 #Done for the g1 case for now
 
 #First run individual time series regressions
-for (i in 1:N) {
+for (i in seq_len(N)) {
   #True Returns
   Rs <- rt_panel_g1_A1[i, , ]
   R_bar[i, 1] <- mean(Rs)
@@ -753,7 +753,7 @@ panel_tune_stats <- function(return_panel, signal_panel, true_factor_panel) {
     annual_vol <- matrix(0, N, 1)
     
     #First run individual time series regressions
-    for (i in 1:N) {
+    for (i in seq_len(N)) {
       #True Returns
       Rs <- return_panel[i, , ]
       R_bar[i, 1] <- mean(Rs)
@@ -865,7 +865,7 @@ panel_tune_stats <- function(return_panel, signal_panel, factor_panel) {
     annual_vol <- matrix(0, N, 1)
     
     #First run individual time series regressions
-    for (i in 1:N) {
+    for (i in seq_len(N)) {
       #True Returns
       Rs <- return_panel[i, , ]
       R_bar[i, 1] <- mean(Rs)
@@ -977,13 +977,13 @@ gen_predictor_z <- function(C, x){
   
   dimnames(xt_set)[[1]][1] <- "constant"
   
-  stock_dim <- paste0("stock_", c(1:N))
+  stock_dim <- paste0("stock_", c(seq_len(N)))
   c_dim <- dimnames(kronecker(t(xt_set[, 1]), t(C[1, , 1]), make.dimnames = TRUE))[[2]]
   time_dim <- paste0("time_", c(1:(Time)))
   
   z_panel <- array(0, dim = c(N, (nrow(xt_set)) * P_c, Time), dimnames = list(stock_dim, c_dim, time_dim))
   
-  for (i in 1:N) {
+  for (i in seq_len(N)) {
     for (t in 1:Time) {
       z_panel[i, , t] <- kronecker(t(xt_set[, t]), t(C[i, , t]), make.dimnames = TRUE)
     }
@@ -1001,7 +1001,7 @@ gen_predictor_z <- function(C, x){
 
 gen_predictor_z_twoway <- function(C, x){
   
-  stock_dim <- paste0("stock_", c(1:N))
+  stock_dim <- paste0("stock_", c(seq_len(N)))
   time_dim <- paste0("time_", c(1:(Time)))
   
   z_panel_base <- array(0, dim = c(N, P_c + nrow(x), Time), dimnames = list(stock_dim, append(dimnames(x)[[1]], dimnames(C)[[2]]), time_dim))
@@ -1035,13 +1035,13 @@ gen_predictor_z_twoway <- function(C, x){
 
 bind_rt_predictor <- function(rt_panel, z_panel) {
   
-  df <- cbind(data.frame(rt_panel[, , 1]), time = 2, stock = paste0("stock_", c(1:N)), data.frame(z_panel[, , 1]))
+  df <- cbind(data.frame(rt_panel[, , 1]), time = 2, stock = paste0("stock_", c(seq_len(N))), data.frame(z_panel[, , 1]))
 
   colnames(df)[1] <- "rt"
   row.names(df) <- NULL
   
   for (t in 2:Time) {
-    df_new <- cbind(data.frame(rt_panel[, , t]), time = 1+t, stock = paste0("stock_", c(1:N)), data.frame(z_panel[, , t]))
+    df_new <- cbind(data.frame(rt_panel[, , t]), time = 1+t, stock = paste0("stock_", c(seq_len(N))), data.frame(z_panel[, , t]))
     colnames(df_new)[1] <- "rt"
     row.names(df_new) <- NULL
     df <- rbind(df, df_new)


### PR DESCRIPTION
Replaced legacy 1:length() and 1:N iterators with safer seq_along() and seq_len() equivalents in verified blocks of Rmd files.

---
*PR created automatically by Jules for task [11193708223690273076](https://jules.google.com/task/11193708223690273076) started by @zeyuz35*