### PR TITLE
⚡ Bolt: Replace dplyr::filter with base R subsetting for performance in foreach loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Base R Subsetting for Faster Iterations
+**Learning:** Using `dplyr::filter()` inside long-running `for` loops and `foreach` constructs introduces significant overhead. The same row subsetting operation can be performed much faster using base R matrix/data.frame subsetting like `dataset[dataset$time == time_periods[t], ]`.
+**Action:** When working on performance refactors inside tightly constrained iterative environments in R, prefer base R subset operations over dplyr verbs when filtering by a simple condition.

--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -229,8 +229,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
     
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     # Mean Case
     if (impute_type == "mean") {
@@ -263,8 +262,7 @@ impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
   imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     if (impute_type == "median") {
       # Impute the median for ALL columns
@@ -303,8 +301,7 @@ cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
   normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     dataset_cross_section_y <- dataset_cross_section %>%
       dplyr::select(time, stock, rt)
@@ -636,8 +633,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(lm_model, newdata = test_cross_section)
     
@@ -655,8 +651,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
 
     test_cross_section_x <- as.matrix(test_cross_section[4:ncol(test_cross_section)])
     
@@ -677,8 +672,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(rf_model, newdata = test_cross_section)$predicted
     
@@ -696,8 +690,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     test_cross_section_x <- test_cross_section[4:ncol(test_cross_section)]
     

--- a/R/empirical_robustness/ff_factors/Real Data.Rmd
+++ b/R/empirical_robustness/ff_factors/Real Data.Rmd
@@ -235,8 +235,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
     
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     # Mean Case
     if (impute_type == "mean") {
@@ -269,8 +268,7 @@ impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
   imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     if (impute_type == "median") {
       # Impute the median for ALL columns
@@ -309,8 +307,7 @@ cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
   normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     dataset_cross_section_y <- dataset_cross_section %>%
       dplyr::select(time, stock, rt)
@@ -689,8 +686,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(lm_model, newdata = test_cross_section)
     
@@ -708,8 +704,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
 
     test_cross_section_x <- as.matrix(test_cross_section[4:ncol(test_cross_section)])
     
@@ -730,8 +725,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(rf_model, newdata = test_cross_section)$predicted
     
@@ -749,8 +743,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     test_cross_section_x <- test_cross_section[4:ncol(test_cross_section)]
     

--- a/R/empirical_robustness/missing_threshold/Real Data.Rmd
+++ b/R/empirical_robustness/missing_threshold/Real Data.Rmd
@@ -228,8 +228,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
     
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     # Mean Case
     if (impute_type == "mean") {
@@ -262,8 +261,7 @@ impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
   imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     if (impute_type == "median") {
       # Impute the median for ALL columns
@@ -302,8 +300,7 @@ cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
   normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     dataset_cross_section_y <- dataset_cross_section %>%
       dplyr::select(time, stock, rt)
@@ -635,8 +632,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(lm_model, newdata = test_cross_section)
     
@@ -654,8 +650,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
 
     test_cross_section_x <- as.matrix(test_cross_section[4:ncol(test_cross_section)])
     
@@ -676,8 +671,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(rf_model, newdata = test_cross_section)$predicted
     
@@ -695,8 +689,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     test_cross_section_x <- test_cross_section[4:ncol(test_cross_section)]
     

--- a/R/empirical_robustness/train_valid_1/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_1/Real Data.Rmd
@@ -226,8 +226,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
     
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     # Mean Case
     if (impute_type == "mean") {
@@ -260,8 +259,7 @@ impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
   imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     if (impute_type == "median") {
       # Impute the median for ALL columns
@@ -300,8 +298,7 @@ cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
   normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     dataset_cross_section_y <- dataset_cross_section %>%
       dplyr::select(time, stock, rt)
@@ -633,8 +630,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %dopar% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(lm_model, newdata = test_cross_section)
     
@@ -652,8 +648,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %dopar% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
 
     test_cross_section_x <- as.matrix(test_cross_section[4:ncol(test_cross_section)])
     
@@ -674,8 +669,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(rf_model, newdata = test_cross_section)$predicted
     
@@ -693,8 +687,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     test_cross_section_x <- test_cross_section[4:ncol(test_cross_section)]
     

--- a/R/empirical_robustness/train_valid_2/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_2/Real Data.Rmd
@@ -228,8 +228,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
     
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     # Mean Case
     if (impute_type == "mean") {
@@ -262,8 +261,7 @@ impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
   imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     if (impute_type == "median") {
       # Impute the median for ALL columns
@@ -302,8 +300,7 @@ cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
   normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
-    dataset_cross_section <- dataset %>%
-      filter(time == time_periods[t])
+    dataset_cross_section <- dataset[dataset$time == time_periods[t], ]
     
     dataset_cross_section_y <- dataset_cross_section %>%
       dplyr::select(time, stock, rt)
@@ -635,8 +632,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %dopar% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(lm_model, newdata = test_cross_section)
     
@@ -654,8 +650,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %dopar% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
 
     test_cross_section_x <- as.matrix(test_cross_section[4:ncol(test_cross_section)])
     
@@ -680,8 +675,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(rf_model, newdata = test_cross_section)$predicted
     
@@ -699,8 +693,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     test_cross_section_x <- test_cross_section[4:ncol(test_cross_section)]
     

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -213,8 +213,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(lm_model, newdata = test_cross_section)
     
@@ -232,8 +231,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
 
     test_cross_section_x <- as.matrix(test_cross_section[4:ncol(test_cross_section)])
     
@@ -254,8 +252,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     residuals <- test_cross_section$rt - predict(rf_model, newdata = test_cross_section)$predicted
     
@@ -273,8 +270,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   # Set .combine to "c" to return a vector of results, which is what we want
   ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
     
-    test_cross_section <- test %>%
-      filter(time == time_periods[t])
+    test_cross_section <- test[test$time == time_periods[t], ]
     
     test_cross_section_x <- test_cross_section[4:ncol(test_cross_section)]
     


### PR DESCRIPTION
Replaced dplyr::filter overhead with base R subsetting within foreach loops, avoiding heavy performance bottlenecks during iterative subsets.

---
*PR created automatically by Jules for task [11983012361250738245](https://jules.google.com/task/11983012361250738245) started by @zeyuz35*