### PR TITLE
⚡ Bolt: Optimize dataframe accumulation using do.call rbind

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Optimize get_ELN_best_tune function
+**Learning:** In R, dynamically growing a dataframe/matrix within a for loop using `rbind` scales poorly (O(N^2)) due to repeated memory allocations and copying. This pattern was found in `get_ELN_best_tune` in multiple Rmd files.
+**Action:** Replace `for (i in ...) rbind(...)` with `do.call(rbind, lapply(..., cbind(...)))` to allocate memory once and dramatically improve performance.

--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -815,10 +815,9 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(seq_along(model_grid), function(model_grid_ii) {
+    cbind(model_grid[[model_grid_ii]]$ELN_grid, list_index = model_grid_ii)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }

--- a/R/empirical_robustness/ff_factors/Real Data.Rmd
+++ b/R/empirical_robustness/ff_factors/Real Data.Rmd
@@ -868,10 +868,9 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(seq_along(model_grid), function(model_grid_ii) {
+    cbind(model_grid[[model_grid_ii]]$ELN_grid, list_index = model_grid_ii)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }

--- a/R/empirical_robustness/missing_threshold/Real Data.Rmd
+++ b/R/empirical_robustness/missing_threshold/Real Data.Rmd
@@ -816,10 +816,9 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(seq_along(model_grid), function(model_grid_ii) {
+    cbind(model_grid[[model_grid_ii]]$ELN_grid, list_index = model_grid_ii)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }

--- a/R/empirical_robustness/train_valid_1/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_1/Real Data.Rmd
@@ -813,10 +813,9 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(seq_along(model_grid), function(model_grid_ii) {
+    cbind(model_grid[[model_grid_ii]]$ELN_grid, list_index = model_grid_ii)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }

--- a/R/empirical_robustness/train_valid_2/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_2/Real Data.Rmd
@@ -818,10 +818,9 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(seq_along(model_grid), function(model_grid_ii) {
+    cbind(model_grid[[model_grid_ii]]$ELN_grid, list_index = model_grid_ii)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -453,10 +453,9 @@ ELN_model_grid <- function(ELN_grid, train_x, train_y, validation_x, validation_
 }
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(seq_along(model_grid), function(model_grid_ii) {
+    cbind(model_grid[[model_grid_ii]]$ELN_grid, list_index = model_grid_ii)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }
@@ -582,10 +581,9 @@ ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validatio
 # Use in conjunction with previous function
 
 get_ELN_best_tune <- function(model_grid) {
-  ELN_tune_dataframe <- cbind(model_grid[[1]]$ELN_grid, list_index = 1)
-  for (i in 2:length(model_grid)) {
-    ELN_tune_dataframe <- rbind(ELN_tune_dataframe, cbind(model_grid[[i]]$ELN_grid, list_index = i))
-  }
+  ELN_tune_dataframe <- do.call(rbind, lapply(seq_along(model_grid), function(model_grid_ii) {
+    cbind(model_grid[[model_grid_ii]]$ELN_grid, list_index = model_grid_ii)
+  }))
   ELN_tune_dataframe <- data.frame(ELN_tune_dataframe)
   return(ELN_tune_dataframe[which.min(ELN_tune_dataframe$validation_loss), ])
 }


### PR DESCRIPTION
Replaces inefficient iterative rbind calls in get_ELN_best_tune with do.call(rbind, lapply(...)) to improve execution speed and memory efficiency

---
*PR created automatically by Jules for task [7374010423574725521](https://jules.google.com/task/7374010423574725521) started by @zeyuz35*