### PR TITLE
📝 Docent: Replace cat() with message() in GLM demo script

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2024-05-30 - Replace cat() with message() in scripts
+**Learning:** The project's `agents.md` file specifies under "Content and Communication Standards" (line 39): "- Replace `cat()` calls used for progress reporting or informational messages with `base::message()`".
+**Action:** Replace `cat()` with `message()` in demo R scripts like `R/xgboost/demo/generalized_linear_model.R` or `R/xgboost/demo/cross_validation.R`. Since `message()` automatically appends a newline, any trailing `\n` in the string passed to `cat()` should be removed.

--- a/R/xgboost/demo/generalized_linear_model.R
+++ b/R/xgboost/demo/generalized_linear_model.R
@@ -30,5 +30,5 @@ num_round <- 2
 bst <- xgb.train(param, dtrain, num_round, watchlist)
 ypred <- predict(bst, dtest)
 labels <- getinfo(dtest, 'label')
-cat('error of preds=', mean(as.numeric(ypred>0.5)!=labels),'\n')
+message('error of preds=', mean(as.numeric(ypred>0.5)!=labels))
 


### PR DESCRIPTION
This PR replaces a raw `cat()` call with `message()` in `R/xgboost/demo/generalized_linear_model.R` to comply with the communication standards specified in `agents.md`, which mandates replacing `cat()` used for informational messages. I also removed the trailing newline `\n` as `message()` automatically appends it.

---
*PR created automatically by Jules for task [9544169733507465097](https://jules.google.com/task/9544169733507465097) started by @zeyuz35*