### PR TITLE
⚡ Bolt: Vectorize array subsetting in LSTM variable importance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-31 - Vectorize array subsetting in LSTM
+**Learning:** Native array and matrix vectorization in R is significantly faster than using manual nested loops to iterate over dimension boundaries.
+**Action:** Replace explicit loop assignments (like for loops iterating over dim) with direct vectorized slice assignments.

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -1331,9 +1331,7 @@ LSTM_variable_importance <- function(X_array_test, Y_array_test, test_x, lstm_mo
     index <- seq(1, 200, by = 1) + (i - 1)*200
     
     X_array_test_zero <- X_array_test
-    for (t in 1:dim(X_array_test)[1]) {
-      X_array_test_zero[t, 1, index] <- 0
-    }
+    X_array_test_zero[, 1, index] <- 0
 
     original_R2 <- R2(predict(lstm_model, X_array_test), Y_array_test %>% as.vector(), form = "traditional")
 


### PR DESCRIPTION
Replaced manual nested loop iterating over dimension boundaries with direct native vectorized slice assignments in `LSTM_variable_importance` to significantly improve performance when assigning zero to indices.

---
*PR created automatically by Jules for task [9114278679314409436](https://jules.google.com/task/9114278679314409436) started by @zeyuz35*