### PR TITLE
🛡️ Sentinel: Remove hardcoded RStudio password in AWS templates

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - Hardcoded RStudio Password in AWS CloudFormation Templates
+**Vulnerability:** Found hardcoded password 'rstudio' used to create an rstudio user in `R/AWS/sagemaker_stack.txt` and `R/AWS/template1` EC2 UserData blocks.
+**Learning:** Hardcoding passwords in infrastructure-as-code templates makes them visible to anyone who has access to the template and risks deploying instances with weak, known default passwords.
+**Prevention:** Always use secure parameterization with `NoEcho: true` for passwords and secrets in CloudFormation templates to inject them securely at stack creation time.

--- a/R/AWS/sagemaker_stack.txt
+++ b/R/AWS/sagemaker_stack.txt
@@ -2,6 +2,11 @@ Parameters:
   KeyName:
     Description: SSH key pair to use for instance login
     Type: AWS::EC2::KeyPair::KeyName
+  RStudioPassword:
+    NoEcho: true
+    Description: Password for the RStudio user
+    Type: String
+    MinLength: 8
 
 Mappings:
   Region:
@@ -94,7 +99,7 @@ Resources:
           sudo pip install sagemaker boto3
           sudo R -e "install.packages(c('reticulate', 'curl', 'tidyverse'), repos = 'http://cran.rstudio.com')"
           sudo adduser rstudio
-          sudo sh -c "echo rstudio | passwd rstudio --stdin"
+          sudo sh -c "echo ${RStudioPassword} | passwd rstudio --stdin"
           wget https://download2.rstudio.org/rstudio-server-rhel-1.2.5033-x86_64.rpm
           sudo apt install -y rstudio-server-rhel-1.2.5033-x86_64.rpm
           sudo -u rstudio mkdir /home/rstudio/.aws

--- a/R/AWS/template1
+++ b/R/AWS/template1
@@ -2,6 +2,11 @@ Parameters:
   KeyName:
     Description: SSH key pair to use for instance login
     Type: AWS::EC2::KeyPair::KeyName
+  RStudioPassword:
+    NoEcho: true
+    Description: Password for the RStudio user
+    Type: String
+    MinLength: 8
 
 Mappings:
   Region:
@@ -95,7 +100,7 @@ Resources:
           sudo pip install sagemaker boto3
           sudo R -e "install.packages(c('reticulate', 'readr', 'curl', 'ggplot2', 'dplyr', 'stringr'), repos = 'http://cran.rstudio.com')"
           sudo adduser rstudio
-          sudo sh -c "echo rstudio | passwd rstudio --stdin"
+          sudo sh -c "echo ${RStudioPassword} | passwd rstudio --stdin"
           wget https://download2.rstudio.org/rstudio-server-rhel-1.1.456-x86_64.rpm
           sudo yum install -y rstudio-server-rhel-1.1.456-x86_64.rpm
           sudo -u rstudio mkdir /home/rstudio/.aws


### PR DESCRIPTION
Removes hardcoded default passwords for the RStudio user in AWS CloudFormation templates (sagemaker_stack.txt and template1) by adding a parameterized `RStudioPassword` parameter with `NoEcho: true`.

---
*PR created automatically by Jules for task [209998602611400793](https://jules.google.com/task/209998602611400793) started by @zeyuz35*