### PR TITLE
⚙️ Modernizer: Optimize array subsetting by removing loop

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,1 +1,4 @@
 ## Modernizer Journal
+## 2026-06-01 - Vectorize array slice assignment
+**Learning:** Nested loops iterating over array/matrix dimension boundaries (e.g., `for (t in 1:dim(X)[1]) { X[t, 1, index] <- 0 }`) are slow and less readable.
+**Action:** Replace explicit loop dimensions with direct vectorized slice assignments (e.g., `X[, 1, index] <- 0`) to improve performance and code readability natively.

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -1331,9 +1331,7 @@ LSTM_variable_importance <- function(X_array_test, Y_array_test, test_x, lstm_mo
     index <- seq(1, 200, by = 1) + (i - 1)*200
     
     X_array_test_zero <- X_array_test
-    for (t in 1:dim(X_array_test)[1]) {
-      X_array_test_zero[t, 1, index] <- 0
-    }
+    X_array_test_zero[, 1, index] <- 0
 
     original_R2 <- R2(predict(lstm_model, X_array_test), Y_array_test %>% as.vector(), form = "traditional")
 


### PR DESCRIPTION
Vectorizes array index assignment in `LSTM_variable_importance` by replacing explicit loop across dimensions with direct slice assignment `X_array_test_zero[, 1, index] <- 0`. This increases performance and simplifies readability without changing behavior.

---
*PR created automatically by Jules for task [6671407193724541088](https://jules.google.com/task/6671407193724541088) started by @zeyuz35*