### PR TITLE
📝 Docent: Replace print/cat with message in R script

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Replace print/cat with message in R
+**Learning:** Found instances of `cat` and `print` being used for structured logging in R scripts (like `R/xgboost/demo/cross_validation.R`).
+**Action:** Replace them with `message` which is proper for structured logging and removes the need for explicit newline `\n`.

--- a/R/xgboost/demo/cross_validation.R
+++ b/R/xgboost/demo/cross_validation.R
@@ -8,13 +8,13 @@ dtest <- xgb.DMatrix(agaricus.test$data, label = agaricus.test$label)
 nrounds <- 2
 param <- list(max_depth=2, eta=1, silent=1, nthread=2, objective='binary:logistic')
 
-cat('running cross validation\n')
+message('running cross validation')
 # do cross validation, this will print result out as
 # [iteration]  metric_name:mean_value+std_value
 # std_value is standard deviation of the metric
 xgb.cv(param, dtrain, nrounds, nfold=5, metrics={'error'})
 
-cat('running cross validation, disable standard deviation display\n')
+message('running cross validation, disable standard deviation display')
 # do cross validation, this will print result out as
 # [iteration]  metric_name:mean_value+std_value
 # std_value is standard deviation of the metric
@@ -25,7 +25,7 @@ xgb.cv(param, dtrain, nrounds, nfold=5,
 # you can also do cross validation with cutomized loss function
 # See custom_objective.R
 ##
-print ('running cross validation, with cutomsized loss function')
+message('running cross validation, with customized loss function')
 
 logregobj <- function(preds, dtrain) {
   labels <- getinfo(dtrain, "label")


### PR DESCRIPTION
Replaced `cat` and `print` statements with `message` for structured logging in `R/xgboost/demo/cross_validation.R`. Fixed typos in logging strings. Verified manually since `xgboost` is not available in the current environment.

---
*PR created automatically by Jules for task [7629577841041902098](https://jules.google.com/task/7629577841041902098) started by @zeyuz35*