### PR TITLE
⚡ Bolt: Vectorize array slice assignment in LSTM variable importance calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,9 @@
+## 2024-05-19 - Vectorize explicitly looped multidimensional array assignment
+**Learning:** `R/simulation/Simulation Models.Rmd` uses an explicit `for` loop over `t` to zero out parts of an array slice:
+```R
+    for (t in 1:dim(X_array_test)[1]) {
+      X_array_test_zero[t, 1, index] <- 0
+    }
+```
+In R, this is an inefficient O(N) pattern. Array indexing supports fully vectorized multi-dimensional slices. We can just use `X_array_test_zero[, 1, index] <- 0` to achieve exactly the same outcome natively and instantly, completely eliminating the loop.
+**Action:** Replace `for` loop indexing with vectorized assignment to improve performance, following the `bolt` agent rule: "In R, to maximize performance, prefer native array and matrix vectorization over manual iterative subsets. Replace explicit nested loops iterating over dimension boundaries (e.g., `for (t in 1:dim(X)[1]) { X[t, 1, index] <- 0 }`) with direct vectorized slice assignments (e.g., `X[, 1, index] <- 0`)."

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -1331,9 +1331,7 @@ LSTM_variable_importance <- function(X_array_test, Y_array_test, test_x, lstm_mo
     index <- seq(1, 200, by = 1) + (i - 1)*200
     
     X_array_test_zero <- X_array_test
-    for (t in 1:dim(X_array_test)[1]) {
-      X_array_test_zero[t, 1, index] <- 0
-    }
+      X_array_test_zero[, 1, index] <- 0
 
     original_R2 <- R2(predict(lstm_model, X_array_test), Y_array_test %>% as.vector(), form = "traditional")
 


### PR DESCRIPTION
This PR replaces a manual `for` loop iterating over array slice dimensions in `LSTM_variable_importance` with direct base R vectorized slice assignment (`X_array_test_zero[, 1, index] <- 0`) to resolve an O(N) bottleneck and improve performance.

---
*PR created automatically by Jules for task [9338583926851042038](https://jules.google.com/task/9338583926851042038) started by @zeyuz35*