### PR TITLE
🛡️ Sentinel: Remove hardcoded S3 bucket name in SageMaker scripts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-04 - Remove hardcoded S3 bucket name
+**Vulnerability:** Hardcoded S3 bucket names in R scripts (e.g. sagemaker-us-west-2-438078873022).
+**Learning:** Hardcoding S3 bucket names can expose infrastructure details and create security/operational risks if the bucket changes or belongs to a specific account.
+**Prevention:** Always use dynamic variables or configuration files for infrastructure references, like `session$default_bucket()`.

--- a/R/AWS/sagemaker.R
+++ b/R/AWS/sagemaker.R
@@ -426,8 +426,8 @@ deepar_fit_stats <- function(pooled_panel, timeSlices) {
       test_quantiles = array(0.5)
     )
     
-    s3_train_input <- "s3://sagemaker-us-west-2-438078873022/data/pooled_panel_train.json"
-    s3_valid_input <- "s3://sagemaker-us-west-2-438078873022/data/pooled_panel_validation.json"
+    s3_train_input <- paste0("s3://", s3_bucket, "/data/pooled_panel_train.json")
+    s3_valid_input <- paste0("s3://", s3_bucket, "/data/pooled_panel_validation.json")
     
     data_channels <- list('train' = s3_train_input, 'test' = s3_valid_input)
     

--- a/R/AWS/sagemaker_run.R
+++ b/R/AWS/sagemaker_run.R
@@ -218,8 +218,8 @@ estimator$set_hyperparameters(
   test_quantiles = array(0.5)
 )
 
-s3_train_input <- "s3://sagemaker-us-west-2-438078873022/data/pooled_panel_train.json"
-s3_valid_input <- "s3://sagemaker-us-west-2-438078873022/data/pooled_panel_test.json"
+s3_train_input <- paste0("s3://", s3_bucket, "/data/pooled_panel_train.json")
+s3_valid_input <- paste0("s3://", s3_bucket, "/data/pooled_panel_test.json")
 
 data_channels <- list('train' = s3_train_input, 'test' = s3_valid_input)
 
@@ -474,8 +474,8 @@ deepar_fit_stats <- function(pooled_panel, timeSlices) {
       test_quantiles = array(0.5)
     )
     
-    s3_train_input <- "s3://sagemaker-us-west-2-438078873022/data/pooled_panel_train.json"
-    s3_valid_input <- "s3://sagemaker-us-west-2-438078873022/data/pooled_panel_test.json"
+    s3_train_input <- paste0("s3://", s3_bucket, "/data/pooled_panel_train.json")
+    s3_valid_input <- paste0("s3://", s3_bucket, "/data/pooled_panel_test.json")
     
     data_channels <- list('train' = s3_train_input, 'test' = s3_valid_input)
     

--- a/test_parse.R
+++ b/test_parse.R
@@ -1,0 +1,3 @@
+parse("R/AWS/sagemaker.R")
+parse("R/AWS/sagemaker_run.R")
+print("Syntax OK")


### PR DESCRIPTION
This PR replaces hardcoded S3 bucket names with dynamic variables in SageMaker scripts, preventing potential exposure of infrastructure details and avoiding operational issues.

---
*PR created automatically by Jules for task [4559638751449610696](https://jules.google.com/task/4559638751449610696) started by @zeyuz35*