### PR TITLE
📦 Binder: remove unqualified library calls in umap_play

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Replacing Unqualified Library Calls
+**Learning:** `agents.md` strictly prohibits `library()` or `require()` within function definitions, and more broadly in the `R/` directory (Stage 2 development) states: "Replace all unqualified external function calls with explicit `pkg::function()` syntax". Using `library()` inside `R/` files litters the global namespace and violates standard R package development practices. Since there's no `DESCRIPTION` file, dependencies aren't being properly managed, but `library()` calls still pollute the workspace.
+**Action:** I will remove the top-level `library()` calls from `R/umap_play.R` and instead namespace the function calls directly (e.g., `umap::umap()`, `dplyr::select()`).

--- a/R/umap_play.R
+++ b/R/umap_play.R
@@ -1,16 +1,6 @@
-library(umap)
-library(purrr)
-library(tidyr)
-library(dplyr)
-library(ggplot2)
-library(Rtsne)
-#devtools::install_github("robjhyndman/tsfeatures")
-library(tsfeatures)
-library(gganimate) # required for printing tours
-library(sneezy)
 final_dataset <- readRDS("~/Dropbox/website/Evaluation-of-Machine-Learning-in-Asset-Pricing/R/final_dataset.rds")
 
-final_dataset_t<-final_dataset%>%select(-rt)
+final_dataset_t<-dplyr::select(final_dataset, -rt)
 
 row_sample<- sample(2:18048,3000, replace=F)
 col_sample<- sample(1:740,500, replace=F)
@@ -19,24 +9,24 @@ data.temp<- final_dataset[row_sample,]
 
 data.temp[is.na(data.temp)] <- 0
 
-data.umap = umap(data.temp)
+data.umap = umap::umap(data.temp)
 
 
 d_umap_1 = as.data.frame(data.umap$layout)  
 
-ggplot(d_umap_1, aes(x=V1, y=V2)) +  
-  geom_point(size=0.25) +
-  guides(colour=guide_legend(override.aes=list(size=6)))
+ggplot2::ggplot(d_umap_1, ggplot2::aes(x=V1, y=V2)) +
+  ggplot2::geom_point(size=0.25) +
+  ggplot2::guides(colour=ggplot2::guide_legend(override.aes=list(size=6)))
 
 
-tsne <- Rtsne(data.temp, dims = 2, perplexity=35, verbose=TRUE, max_iter = 2000)
+tsne <- Rtsne::Rtsne(data.temp, dims = 2, perplexity=35, verbose=TRUE, max_iter = 2000)
 
 
 ## Plotting
 d_tsne_1 = as.data.frame(tsne$Y)  
-ggplot(d_tsne_1, aes(x=V1, y=V2)) +  
-  geom_point(size=0.25) +
-  guides(colour=guide_legend(override.aes=list(size=6)))
+ggplot2::ggplot(d_tsne_1, ggplot2::aes(x=V1, y=V2)) +
+  ggplot2::geom_point(size=0.25) +
+  ggplot2::guides(colour=ggplot2::guide_legend(override.aes=list(size=6)))
 
 
 


### PR DESCRIPTION
Removed explicit top-level library() calls from R/umap_play.R and replaced them with fully qualified namespace calls (e.g. umap::umap()). This adheres to the project's namespace guidelines.

---
*PR created automatically by Jules for task [4829930422184845970](https://jules.google.com/task/4829930422184845970) started by @zeyuz35*