### PR TITLE
⚡ Bolt: Replace manual loop with vectorized array assignment

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Native array vectorization
+**Learning:** Manual loops over array dimension boundaries for scalar assignment (e.g., `for (t in 1:dim(X)[1]) { X[t, 1, index] <- 0 }`) are much slower in R compared to native vectorized slice assignments (e.g., `X[, 1, index] <- 0`).
+**Action:** Use vectorization directly when assigning elements or slices of multi-dimensional arrays instead of manually iterating over dimensions.

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -1331,9 +1331,7 @@ LSTM_variable_importance <- function(X_array_test, Y_array_test, test_x, lstm_mo
     index <- seq(1, 200, by = 1) + (i - 1)*200
     
     X_array_test_zero <- X_array_test
-    for (t in 1:dim(X_array_test)[1]) {
-      X_array_test_zero[t, 1, index] <- 0
-    }
+    X_array_test_zero[, 1, index] <- 0
 
     original_R2 <- R2(predict(lstm_model, X_array_test), Y_array_test %>% as.vector(), form = "traditional")
 


### PR DESCRIPTION
Replaced a manual `for` loop over `dim(X_array_test)[1]` with a native vectorized slice assignment `X_array_test_zero[, 1, index] <- 0` to improve performance.

---
*PR created automatically by Jules for task [11967336073877666175](https://jules.google.com/task/11967336073877666175) started by @zeyuz35*