### PR TITLE
🗃️ Curator: Fix silent type coercion and nested lists in AWS JSON data prep

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Fix List Column Flattening
+**Learning:** Assigning a list object (e.g., `list(c(5, 6))`) to a single element of an integer vector within a dataframe (e.g., `df$target[1] <- list(...)`) silently coerces the input into the vector's type, effectively flattening the structure or completely dropping the list wrapping.
+**Action:** When initializing a dataframe with list columns, use `I(vector("list", N))` instead of standard numerical initializations. Additionally, to assign to an element of a list column, use double-bracket indexing `df$target[[1]] <- c(5, 6)`.

--- a/R/AWS/json.Rmd
+++ b/R/AWS/json.Rmd
@@ -34,13 +34,13 @@ dummy_data %>%
 stock_id <- pooled_panel$stock %>%
   unique()
 
-pooled_panel_json <- data.frame(start = c(1:200), target = c(1:200), dynamic_feat = c(1:200))
+pooled_panel_json <- data.frame(start = c(1:200), target = I(vector("list", 200)), dynamic_feat = I(vector("list", 200)))
 
 for (i in 1:200) {
   pooled_panel_filter <- pooled_panel %>%
     filter(stock == stock_id[i])
   
-  pooled_panel_json$target[i] <- list(pooled_panel_filter$rt)
+  pooled_panel_json$target[[i]] <- pooled_panel_filter$rt
   
   pooled_panel_filter_feature <- pooled_panel_filter %>%
     select(-time, -rt, -stock) %>%
@@ -49,7 +49,7 @@ for (i in 1:200) {
     # Transpose it to get the right format of one feature series per row
     t()
   
-  pooled_panel_json[i, ]$dynamic_feat <- pooled_panel_filter_feature %>% list()
+  pooled_panel_json$dynamic_feat[[i]] <- pooled_panel_filter_feature
 }
 
 ## Function that takes data frame in tidy format, and outputs a dataframe 
@@ -64,14 +64,14 @@ tidy_to_json <- function(data) {
   
   ## JUst setting the beginning time to something arbitrary for now, change if needed
   pooled_panel_json <- data.frame(start = rep("2000-01-01 00:00:00", cross_units), 
-                                  target = c(1:cross_units), 
-                                  dynamic_feat = c(1:cross_units))
+                                  target = I(vector("list", cross_units)),
+                                  dynamic_feat = I(vector("list", cross_units)))
   
   for (i in 1:cross_units) {
     pooled_panel_filter <- data %>%
       filter(stock == stock_id[i])
     
-    pooled_panel_json$target[i] <- list(pooled_panel_filter$rt)
+    pooled_panel_json$target[[i]] <- pooled_panel_filter$rt
     
     pooled_panel_filter_feature <- pooled_panel_filter %>%
       select(-time, -rt, -stock) %>%
@@ -80,7 +80,7 @@ tidy_to_json <- function(data) {
       # Transpose it to get the right format of one feature series per row
       t()
     
-    pooled_panel_json[i, ]$dynamic_feat <- pooled_panel_filter_feature %>% list()
+    pooled_panel_json$dynamic_feat[[i]] <- pooled_panel_filter_feature
   }
   
   pooled_panel_json

--- a/R/AWS/sagemaker.R
+++ b/R/AWS/sagemaker.R
@@ -158,11 +158,11 @@ tidy_to_json <- function(data, start) {
   
   ## JUst setting the beginning time to something arbitrary for now, change if needed
   pooled_panel_json <- data.frame(start = rep(start, cross_units), 
-                                  target = c(1:cross_units), 
-                                  dynamic_feat = c(1:cross_units))
+                                  target = I(vector("list", cross_units)),
+                                  dynamic_feat = I(vector("list", cross_units)))
   
   pooled_panel_json <- foreach(i = 1:cross_units, .combine = "rbind") %dopar% {
-    df <- data.frame(start = 0, target = 0, dynamic_feat = 0)
+    df <- data.frame(start = 0, target = I(vector("list", 1)), dynamic_feat = I(vector("list", 1)))
     pooled_panel_filter <- data %>%
       filter(stock == stock_id[i])
     pooled_panel_filter_rt <- pooled_panel_filter$rt %>% list()
@@ -324,8 +324,8 @@ tidy_to_batch_inf <- function(data, start, timeSlices, set) {
   
   ## Just setting the beginning time to something arbitrary for now, change if needed
   pooled_panel_json <- data.frame(start = rep(start, cross_units), 
-                                  target = c(1:cross_units), 
-                                  dynamic_feat = c(1:cross_units))
+                                  target = I(vector("list", cross_units)),
+                                  dynamic_feat = I(vector("list", cross_units)))
   
   for (i in 1:cross_units) {
     pooled_panel_filter <- data %>%
@@ -334,7 +334,7 @@ tidy_to_batch_inf <- function(data, start, timeSlices, set) {
     pooled_panel_filter_rt <- pooled_panel_filter %>%
       filter(time %in% timeSlices[[set]]$train | time %in% timeSlices[[set]]$validation)
     
-    pooled_panel_json$target[i] <- list(pooled_panel_filter_rt$rt)
+    pooled_panel_json$target[[i]] <- pooled_panel_filter_rt$rt
     
     pooled_panel_filter_feature <- pooled_panel_filter %>%
       filter(time %in% timeSlices[[set]]$train | time %in% timeSlices[[set]]$validation | time %in% timeSlices[[set]]$test) %>%
@@ -344,7 +344,7 @@ tidy_to_batch_inf <- function(data, start, timeSlices, set) {
       # Transpose it to get the right format of one feature series per row
       t()
     
-    pooled_panel_json[i, ]$dynamic_feat <- list(pooled_panel_filter_feature)
+    pooled_panel_json$dynamic_feat[[i]] <- pooled_panel_filter_feature
   }
   pooled_panel_json
 }

--- a/R/AWS/sagemaker_run.R
+++ b/R/AWS/sagemaker_run.R
@@ -133,14 +133,14 @@ tidy_to_json <- function(data, start) {
   
   ## JUst setting the beginning time to something arbitrary for now, change if needed
   pooled_panel_json <- data.frame(start = rep(start, cross_units), 
-                                  target = c(1:cross_units), 
-                                  dynamic_feat = c(1:cross_units))
+                                  target = I(vector("list", cross_units)),
+                                  dynamic_feat = I(vector("list", cross_units)))
   
   for (i in 1:cross_units) {
     pooled_panel_filter <- data %>%
       filter(stock == stock_id[i])
     
-    pooled_panel_json$target[i] <- list(pooled_panel_filter$rt)
+    pooled_panel_json$target[[i]] <- pooled_panel_filter$rt
     
     pooled_panel_filter_feature <- pooled_panel_filter %>%
       select(-time, -rt, -stock) %>%
@@ -149,7 +149,7 @@ tidy_to_json <- function(data, start) {
       # Transpose it to get the right format of one feature series per row
       t()
     
-    pooled_panel_json[i, ]$dynamic_feat <- pooled_panel_filter_feature %>% list()
+    pooled_panel_json$dynamic_feat[[i]] <- pooled_panel_filter_feature
   }
   pooled_panel_json
 }
@@ -350,17 +350,16 @@ tidy_to_batch_inf <- function(data, start, timeSlices, set) {
   
   ## Just setting the beginning time to something arbitrary for now, change if needed
   pooled_panel_json <- data.frame(start = rep(start, cross_units), 
-                                  target = c(1:cross_units), 
-                                  dynamic_feat = c(1:cross_units))
+                                  target = I(vector("list", cross_units)),
+                                  dynamic_feat = I(vector("list", cross_units)))
   
   for (i in 1:cross_units) {
     pooled_panel_filter <- data %>%
       filter(stock == stock_id[i])
       
-    pooled_panel_json$target[i] <- pooled_panel_filter %>%
+    pooled_panel_json$target[[i]] <- (pooled_panel_filter %>%
       filter(time %in% timeSlices[[set]]$train | time %in% timeSlices[[set]]$validation) %>%
-      dplyr::select(rt) %>%
-      list()
+      dplyr::select(rt))$rt
     
     pooled_panel_filter_feature <- pooled_panel_filter %>%
       filter(time %in% timeSlices[[set]]$train | time %in% timeSlices[[set]]$validation | time %in% timeSlices[[set]]$test) %>%
@@ -370,7 +369,7 @@ tidy_to_batch_inf <- function(data, start, timeSlices, set) {
       # Transpose it to get the right format of one feature series per row
       t()
     
-    pooled_panel_json[i, ]$dynamic_feat <- pooled_panel_filter_feature %>% list()
+    pooled_panel_json$dynamic_feat[[i]] <- pooled_panel_filter_feature
   }
   pooled_panel_json
 }

--- a/R/aws_prep.Rmd
+++ b/R/aws_prep.Rmd
@@ -66,14 +66,14 @@ tidy_to_json <- function(data) {
   
   ## JUst setting the beginning time to something arbitrary for now, change if needed
   pooled_panel_json <- data.frame(start = rep("2000-01-01 00:00:00", cross_units), 
-                                  target = c(1:cross_units), 
-                                  dynamic_feat = c(1:cross_units))
+                                  target = I(vector("list", cross_units)),
+                                  dynamic_feat = I(vector("list", cross_units)))
   
   for (i in 1:cross_units) {
     pooled_panel_filter <- data %>%
       filter(stock == stock_id[i])
     
-    pooled_panel_json$target[i] <- list(pooled_panel_filter$rt)
+    pooled_panel_json$target[[i]] <- pooled_panel_filter$rt
     
     pooled_panel_filter_feature <- pooled_panel_filter %>%
       select(-time, -rt, -stock) %>%
@@ -82,7 +82,7 @@ tidy_to_json <- function(data) {
       # Transpose it to get the right format of one feature series per row
       t()
     
-    pooled_panel_json[i, ]$dynamic_feat <- pooled_panel_filter_feature %>% list()
+    pooled_panel_json$dynamic_feat[[i]] <- pooled_panel_filter_feature
   }
   
   pooled_panel_json


### PR DESCRIPTION
This PR fixes a silent type coercion issue in the R data frames used to prep AWS JSON datasets. Assigning `list()` to single atomic numeric vector elements flattens data and causes type instability. The fix initializes list columns with `I(vector('list', N))` and uses double bracket `[[i]]` extraction for stable assignment.

---
*PR created automatically by Jules for task [18003216854055169842](https://jules.google.com/task/18003216854055169842) started by @zeyuz35*