### PR TITLE
📝 Docent: Replace raw cat() with formal message() logging

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,6 @@
+## 2024-05-01 - Initial setup
+**Learning:** Initializing docent log.
+**Action:** Proceed with style and formatting checks.
+## 2024-05-01 - Replace raw cat with message in xgboost demo
+**Learning:** Raw `cat()` commands are often used in R scripts to print formatted information but lack the formal structure of `message()` or actual logging tools. The `message()` function handles line breaks implicitly, preventing the need for `\n` while ensuring formal R logging output.
+**Action:** Found a `cat()` call in `R/xgboost/demo/generalized_linear_model.R` outputting raw prediction errors. Replaced it with a formatted `message()` call and updated `!=` syntax for style adherence.

--- a/R/xgboost/demo/generalized_linear_model.R
+++ b/R/xgboost/demo/generalized_linear_model.R
@@ -30,5 +30,5 @@ num_round <- 2
 bst <- xgb.train(param, dtrain, num_round, watchlist)
 ypred <- predict(bst, dtest)
 labels <- getinfo(dtest, 'label')
-cat('error of preds=', mean(as.numeric(ypred>0.5)!=labels),'\n')
+message('error of preds= ', mean(as.numeric(ypred > 0.5) != labels))
 


### PR DESCRIPTION
Replaces the raw `cat()` output for prediction error in `R/xgboost/demo/generalized_linear_model.R` with a standard R `message()` command for better logging practices and style consistency.

---
*PR created automatically by Jules for task [2622288034835226658](https://jules.google.com/task/2622288034835226658) started by @zeyuz35*