### PR TITLE
📝 Docent: replace cat with message in demo scripts

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2024-06-06 - Replace cat() with message()
+**Learning:** The project's style guide requires `cat()` calls used for progress reporting or informational messages to be replaced with `base::message()`. Explicit newline characters (`\n`) should be removed since `message()` automatically appends a newline.
+**Action:** Used `sed` in a loop to systematically replace `cat(...)` calls with `message(...)` in R files, verifying that trailing `\n` characters are properly removed.

--- a/R/xgboost/demo/create_sparse_matrix.R
+++ b/R/xgboost/demo/create_sparse_matrix.R
@@ -22,11 +22,11 @@ data(Arthritis)
 df <- data.table(Arthritis, keep.rownames = F)
 
 # Let's have a look to the data.table
-cat("Print the dataset\n")
+message("Print the dataset")
 print(df)
 
 # 2 columns have factor type, one has ordinal type (ordinal variable is a categorical variable with values wich can be ordered, here: None > Some > Marked).
-cat("Structure of the dataset\n")
+message("Structure of the dataset")
 str(df)
 
 # Let's add some new categorical features to see if it helps. Of course these feature are highly correlated to the Age feature. Usually it's not a good thing in ML, but Tree algorithms (including boosted trees) are able to select the best features, even in case of highly correlated features.
@@ -41,7 +41,7 @@ df[,AgeCat:= as.factor(ifelse(Age > 30, "Old", "Young"))]
 df[,ID:=NULL]
 
 # List the different values for the column Treatment: Placebo, Treated.
-cat("Values of the categorical feature Treatment\n")
+message("Values of the categorical feature Treatment")
 print(levels(df[,Treatment]))
 
 # Next step, we will transform the categorical data to dummy variables.
@@ -54,7 +54,7 @@ print(levels(df[,Treatment]))
 # Column Improved is excluded because it will be our output column, the one we want to predict.
 sparse_matrix = sparse.model.matrix(Improved~.-1, data = df)
 
-cat("Encoding of the sparse Matrix\n")
+message("Encoding of the sparse Matrix")
 print(sparse_matrix)
 
 # Create the output vector (not sparse)
@@ -64,7 +64,7 @@ print(sparse_matrix)
 output_vector = df[,Y:=0][Improved == "Marked",Y:=1][,Y]
 
 # Following is the same process as other demo
-cat("Learning...\n")
+message("Learning...")
 bst <- xgboost(data = sparse_matrix, label = output_vector, max_depth = 9,
                eta = 1, nthread = 2, nrounds = 10, objective = "binary:logistic")
 

--- a/R/xgboost/demo/cross_validation.R
+++ b/R/xgboost/demo/cross_validation.R
@@ -8,13 +8,13 @@ dtest <- xgb.DMatrix(agaricus.test$data, label = agaricus.test$label)
 nrounds <- 2
 param <- list(max_depth=2, eta=1, silent=1, nthread=2, objective='binary:logistic')
 
-cat('running cross validation\n')
+message('running cross validation')
 # do cross validation, this will print result out as
 # [iteration]  metric_name:mean_value+std_value
 # std_value is standard deviation of the metric
 xgb.cv(param, dtrain, nrounds, nfold=5, metrics={'error'})
 
-cat('running cross validation, disable standard deviation display\n')
+message('running cross validation, disable standard deviation display')
 # do cross validation, this will print result out as
 # [iteration]  metric_name:mean_value+std_value
 # std_value is standard deviation of the metric

--- a/R/xgboost/demo/generalized_linear_model.R
+++ b/R/xgboost/demo/generalized_linear_model.R
@@ -30,5 +30,5 @@ num_round <- 2
 bst <- xgb.train(param, dtrain, num_round, watchlist)
 ypred <- predict(bst, dtest)
 labels <- getinfo(dtest, 'label')
-cat('error of preds=', mean(as.numeric(ypred>0.5)!=labels),'\n')
+message('error of preds= ', mean(as.numeric(ypred>0.5)!=labels))
 

--- a/R/xgboost/demo/predict_first_ntree.R
+++ b/R/xgboost/demo/predict_first_ntree.R
@@ -11,7 +11,7 @@ nrounds = 2
 
 # training the model for two rounds
 bst = xgb.train(param, dtrain, nrounds, nthread = 2, watchlist)
-cat('start testing prediction from first n trees\n')
+message('start testing prediction from first n trees')
 labels <- getinfo(dtest,'label')
 
 ### predict using first 1 tree
@@ -19,5 +19,5 @@ ypred1 = predict(bst, dtest, ntreelimit=1)
 # by default, we predict using all the trees
 ypred2 = predict(bst, dtest)
 
-cat('error of ypred1=', mean(as.numeric(ypred1>0.5)!=labels),'\n')
-cat('error of ypred2=', mean(as.numeric(ypred2>0.5)!=labels),'\n')
+message('error of ypred1= ', mean(as.numeric(ypred1>0.5)!=labels))
+message('error of ypred2= ', mean(as.numeric(ypred2>0.5)!=labels))

--- a/R/xgboost/demo/predict_leaf_indices.R
+++ b/R/xgboost/demo/predict_leaf_indices.R
@@ -50,4 +50,4 @@ bst <- xgb.train(params = param, data = new.dtrain, nrounds = nrounds, nthread =
 accuracy.after <- sum((predict(bst, new.dtest) >= 0.5) == agaricus.test$label) / length(agaricus.test$label)
 
 # Here the accuracy was already good and is now perfect.
-cat(paste("The accuracy was", accuracy.before, "before adding leaf features and it is now", accuracy.after, "!\n"))
+message(paste("The accuracy was", accuracy.before, "before adding leaf features and it is now", accuracy.after, "!"))


### PR DESCRIPTION
Replaces informational `cat()` calls with `message()` in xgboost demo scripts, ensuring explicit newlines are removed, per the project's console output and messaging guidelines.

---
*PR created automatically by Jules for task [12155007964798998866](https://jules.google.com/task/12155007964798998866) started by @zeyuz35*