### PR TITLE
⚙️ Modernizer: Replace 1:length and 1:nrow with safe iteration functions

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,1 +1,3 @@
-## Modernizer Journal
+## 2024-06-07 - Replace 1:length and 1:nrow with seq_along and seq_len
+**Learning:** R loops using `1:length(x)` or `1:nrow(x)` can fail or produce unexpected results if the length is 0 (resulting in a sequence like `1:0`). R's modern, idiomatic approach is to use `seq_along(x)` and `seq_len(nrow(x))` to safely iterate over vectors and rows. This improves both robustness (avoiding the 1:0 bug) and clarity.
+**Action:** Replace `1:length(variable)` with `seq_along(variable)` and `1:nrow(variable)` with `seq_len(nrow(variable))` throughout the `R/` directory.

--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -227,7 +227,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   time_periods <- unique(dataset$time)
   
-  cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  cross_sectional_values_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
@@ -262,7 +262,7 @@ colnames(test)[colSums(is.na(test)) > 0]
 impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
-  imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  imputed_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -302,7 +302,7 @@ ncol(datashare_filtered)
 cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
-  normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  normalize_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -420,7 +420,7 @@ write.csv(individual_factor_names, file = "individual_factor_names.csv")
 ## This section builds in the macro dataset and egnerates the interaction terms
 interaction_terms <- rep(list(0), length(macro_factor_names))
 
-for (i in 1:length(macro_factor_names)) {
+for (i in seq_along(macro_factor_names)) {
   interaction_terms[[i]] <- paste(macro_factor_names[i], individual_factor_names, sep = ":", collapse = " + ")
 }
 
@@ -634,7 +634,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -653,7 +653,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -675,7 +675,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -694,7 +694,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -786,7 +786,7 @@ LM_fit <- function(pooled_panel, timeSlices, loss_function, f,
 
 ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validation_y, loss_function, nlamb) {
   
-  ELN_model_grid_list <- foreach(i = (1:length(alpha_grid))) %dopar% {
+  ELN_model_grid_list <- foreach(i = (seq_along(alpha_grid))) %dopar% {
     ELN_model_grid <- list(ELN_grid = 0, model = 0)
     
     #MSE Case
@@ -908,7 +908,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
   #Initialize List
   RF_model_grid <- rep(list(0), nrow(RF_grid))
   
-  for (i in 1:nrow(RF_grid)) {
+  for (i in seq_len(nrow(RF_grid))) {
     
     RF_model_grid[[i]] <- list(RF_grid = 0, model = 0)
     

--- a/R/empirical_robustness/ff_factors/Real Data.Rmd
+++ b/R/empirical_robustness/ff_factors/Real Data.Rmd
@@ -233,7 +233,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   time_periods <- unique(dataset$time)
   
-  cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  cross_sectional_values_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
@@ -268,7 +268,7 @@ colnames(test)[colSums(is.na(test)) > 0]
 impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
-  imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  imputed_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -308,7 +308,7 @@ ncol(datashare_filtered)
 cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
-  normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  normalize_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -469,7 +469,7 @@ write.csv(individual_factor_names, file = "individual_factor_names.csv")
 ## This section builds in the macro dataset and egnerates the interaction terms
 interaction_terms <- rep(list(0), length(macro_factor_names))
 
-for (i in 1:length(macro_factor_names)) {
+for (i in seq_along(macro_factor_names)) {
   interaction_terms[[i]] <- paste(macro_factor_names[i], individual_factor_names, sep = ":", collapse = " + ")
 }
 
@@ -687,7 +687,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -706,7 +706,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -728,7 +728,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -747,7 +747,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -839,7 +839,7 @@ LM_fit <- function(pooled_panel, timeSlices, loss_function, f,
 
 ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validation_y, loss_function, nlamb) {
   
-  ELN_model_grid_list <- foreach(i = (1:length(alpha_grid))) %dopar% {
+  ELN_model_grid_list <- foreach(i = (seq_along(alpha_grid))) %dopar% {
     ELN_model_grid <- list(ELN_grid = 0, model = 0)
     
     #MSE Case
@@ -961,7 +961,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
   #Initialize List
   RF_model_grid <- rep(list(0), nrow(RF_grid))
   
-  for (i in 1:nrow(RF_grid)) {
+  for (i in seq_len(nrow(RF_grid))) {
     
     RF_model_grid[[i]] <- list(RF_grid = 0, model = 0)
     

--- a/R/empirical_robustness/missing_threshold/Real Data.Rmd
+++ b/R/empirical_robustness/missing_threshold/Real Data.Rmd
@@ -226,7 +226,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   time_periods <- unique(dataset$time)
   
-  cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  cross_sectional_values_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
@@ -261,7 +261,7 @@ colnames(test)[colSums(is.na(test)) > 0]
 impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
-  imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  imputed_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -301,7 +301,7 @@ ncol(datashare_filtered)
 cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
-  normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  normalize_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -419,7 +419,7 @@ write.csv(individual_factor_names, file = "individual_factor_names.csv")
 ## This section builds in the macro dataset and egnerates the interaction terms
 interaction_terms <- rep(list(0), length(macro_factor_names))
 
-for (i in 1:length(macro_factor_names)) {
+for (i in seq_along(macro_factor_names)) {
   interaction_terms[[i]] <- paste(macro_factor_names[i], individual_factor_names, sep = ":", collapse = " + ")
 }
 
@@ -633,7 +633,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -652,7 +652,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -674,7 +674,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -693,7 +693,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -787,7 +787,7 @@ LM_fit <- function(pooled_panel, timeSlices, loss_function, f,
 ```{r}
 ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validation_y, loss_function, nlamb) {
   
-  ELN_model_grid_list <- foreach(i = (1:length(alpha_grid)), .packages = c("hqreg")) %dopar% {
+  ELN_model_grid_list <- foreach(i = (seq_along(alpha_grid)), .packages = c("hqreg")) %dopar% {
     ELN_model_grid <- list(ELN_grid = 0, model = 0)
     
     #MSE Case
@@ -909,7 +909,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
   #Initialize List
   RF_model_grid <- rep(list(0), nrow(RF_grid))
   
-  for (i in 1:nrow(RF_grid)) {
+  for (i in seq_len(nrow(RF_grid))) {
     
     RF_model_grid[[i]] <- list(RF_grid = 0, model = 0)
     

--- a/R/empirical_robustness/train_valid_1/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_1/Real Data.Rmd
@@ -224,7 +224,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   time_periods <- unique(dataset$time)
   
-  cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  cross_sectional_values_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
@@ -259,7 +259,7 @@ colnames(test)[colSums(is.na(test)) > 0]
 impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
-  imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  imputed_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -299,7 +299,7 @@ ncol(datashare_filtered)
 cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
-  normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  normalize_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -417,7 +417,7 @@ write.csv(individual_factor_names, file = "individual_factor_names.csv")
 ## This section builds in the macro dataset and egnerates the interaction terms
 interaction_terms <- rep(list(0), length(macro_factor_names))
 
-for (i in 1:length(macro_factor_names)) {
+for (i in seq_along(macro_factor_names)) {
   interaction_terms[[i]] <- paste(macro_factor_names[i], individual_factor_names, sep = ":", collapse = " + ")
 }
 
@@ -631,7 +631,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %dopar% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %dopar% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -650,7 +650,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %dopar% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %dopar% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -672,7 +672,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -691,7 +691,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -783,7 +783,7 @@ LM_fit <- function(pooled_panel, timeSlices, loss_function, f,
 
 ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validation_y, loss_function, nlamb) {
   
-  ELN_model_grid_list <- foreach(i = (1:length(alpha_grid))) %dopar% {
+  ELN_model_grid_list <- foreach(i = (seq_along(alpha_grid))) %dopar% {
     ELN_model_grid <- list(ELN_grid = 0, model = 0)
     
     #MSE Case
@@ -906,7 +906,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
   #Initialize List
   RF_model_grid <- rep(list(0), nrow(RF_grid))
   
-  for (i in 1:nrow(RF_grid)) {
+  for (i in seq_len(nrow(RF_grid))) {
     
     RF_model_grid[[i]] <- list(RF_grid = 0, model = 0)
     

--- a/R/empirical_robustness/train_valid_2/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_2/Real Data.Rmd
@@ -226,7 +226,7 @@ cross_sectional_values <- function(dataset, impute_type) {
   
   time_periods <- unique(dataset$time)
   
-  cross_sectional_values_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  cross_sectional_values_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
@@ -261,7 +261,7 @@ colnames(test)[colSums(is.na(test)) > 0]
 impute_cross_section <- function(dataset, impute_type) {
   time_periods <- unique(dataset$time)
   
-  imputed_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  imputed_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -301,7 +301,7 @@ ncol(datashare_filtered)
 cross_section_normalize <- function(dataset) {
   time_periods <- unique(dataset$time)
   
-  normalize_cross_section_df <- foreach(t = 1:length(time_periods), .combine = "rbind") %dopar% {
+  normalize_cross_section_df <- foreach(t = seq_along(time_periods), .combine = "rbind") %dopar% {
     dataset_cross_section <- dataset %>%
       filter(time == time_periods[t])
     
@@ -419,7 +419,7 @@ write.csv(individual_factor_names, file = "individual_factor_names.csv")
 ## This section builds in the macro dataset and egnerates the interaction terms
 interaction_terms <- rep(list(0), length(macro_factor_names))
 
-for (i in 1:length(macro_factor_names)) {
+for (i in seq_along(macro_factor_names)) {
   interaction_terms[[i]] <- paste(macro_factor_names[i], individual_factor_names, sep = ":", collapse = " + ")
 }
 
@@ -633,7 +633,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %dopar% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %dopar% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -652,7 +652,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %dopar% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %dopar% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -678,7 +678,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -697,7 +697,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -789,7 +789,7 @@ LM_fit <- function(pooled_panel, timeSlices, loss_function, f,
 
 ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validation_y, loss_function, nlamb) {
   
-  ELN_model_grid_list <- foreach(i = (1:length(alpha_grid))) %dopar% {
+  ELN_model_grid_list <- foreach(i = (seq_along(alpha_grid))) %dopar% {
     ELN_model_grid <- list(ELN_grid = 0, model = 0)
     
     #MSE Case
@@ -913,7 +913,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
   #Initialize List
   RF_model_grid <- rep(list(0), nrow(RF_grid))
   
-  for (i in 1:nrow(RF_grid)) {
+  for (i in seq_len(nrow(RF_grid))) {
     
     RF_model_grid[[i]] <- list(RF_grid = 0, model = 0)
     

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -211,7 +211,7 @@ lm_ave_forecast_resids <- function(lm_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c", .packages = c("speedglm", "quantreg")) %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -230,7 +230,7 @@ eln_ave_forecast_resids <- function(eln_model, test, alpha, lambda) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -252,7 +252,7 @@ rf_ave_forecast_resids <- function(rf_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -271,7 +271,7 @@ nnet_ave_forecast_resids <- function(nnet_model, test) {
   time_periods <- unique(test$time)
   
   # Set .combine to "c" to return a vector of results, which is what we want
-  ave_forecast_resids_vector <- foreach(t = 1:length(time_periods), .combine = "c") %do% {
+  ave_forecast_resids_vector <- foreach(t = seq_along(time_periods), .combine = "c") %do% {
     
     test_cross_section <- test %>%
       filter(time == time_periods[t])
@@ -424,7 +424,7 @@ ELN_grid <- expand.grid(
 ELN_model_grid <- function(ELN_grid, train_x, train_y, validation_x, validation_y, loss_function, nlambda) {
   ELN_model_grid <- rep(list(0), nrow(ELN_grid))
   
-  for (i in 1:nrow(ELN_grid)) {
+  for (i in seq_len(nrow(ELN_grid))) {
     
     ELN_model_grid[[i]] <- list(ELN_grid = 0, model = 0)
     
@@ -553,7 +553,7 @@ alpha_grid <- seq(0, 1, 0.01)
 
 ELN_model_grid <- function(alpha_grid, train_x, train_y, validation_x, validation_y, loss_function, nlamb) {
   
-  ELN_model_grid_list <- foreach(i = (1:length(alpha_grid))) %dopar% {
+  ELN_model_grid_list <- foreach(i = (seq_along(alpha_grid))) %dopar% {
     ELN_model_grid <- list(ELN_grid = 0, model = 0)
     
     #MSE Case
@@ -753,7 +753,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
   #Initialize List
   RF_model_grid <- rep(list(0), nrow(RF_grid))
   
-  for (i in 1:nrow(RF_grid)) {
+  for (i in seq_len(nrow(RF_grid))) {
     
     RF_model_grid[[i]] <- list(RF_grid = 0, model = 0)
     
@@ -1863,7 +1863,7 @@ fforma_data_matrix <- function(pooled_panel) {
 ## Function to return an errors matrix
 
 fforma_errors <- function(fforma_fit, loss_function) {
-  foreach(i = 1:length(fforma_fit), .combine = "rbind") %do% {
+  foreach(i = seq_along(fforma_fit), .combine = "rbind") %do% {
     # MSE
     if (loss_function == "mse") {
       fforma_fit[[i]]$validation_error_mse
@@ -1876,7 +1876,7 @@ fforma_errors <- function(fforma_fit, loss_function) {
 # Labels matrix (using the erros matrix)
 
 fforma_labels <- function(errors) {
-  foreach(i = 1:nrow(errors), .combine = "rbind") %dopar% {
+  foreach(i = seq_len(nrow(errors)), .combine = "rbind") %dopar% {
     data.frame(label = which.min(errors[i, ]) - 1)
   }
 }
@@ -1953,7 +1953,7 @@ error_softmax_obj <- function(preds, dtrain) {
 fforma_fit_stats <- function(pooled_panel, timeSlices, loss_function) {
   fforma_fit_stats_list <- rep(list(0), length(timeSlices))
   
-  for (set in 1:length(fforma_fit_stats_list)) {
+  for (set in seq_along(fforma_fit_stats_list)) {
     fforma_fit_stats_list[[set]] <- list(loss_stats = data.frame(train_MAE = 0, train_MSE = 0, 
                                                                  train_RMSE = 0, train_RSquare = 0, 
                                                                  validation_MAE = 0, validation_MSE = 0,
@@ -2010,7 +2010,7 @@ fforma_fit_stats <- function(pooled_panel, timeSlices, loss_function) {
                     outputmargin = TRUE, reshape=TRUE)
     pred <- t(apply(pred, 1, softmax_transform))
 
-    validation_forecasts <- foreach(i = 1:nrow(pred), .combine = "rbind") %do% {
+    validation_forecasts <- foreach(i = seq_len(nrow(pred)), .combine = "rbind") %do% {
       pred[i, ] %*% fforma_fit[[i]]$validation_forecasts
     }
     
@@ -2020,7 +2020,7 @@ fforma_fit_stats <- function(pooled_panel, timeSlices, loss_function) {
     pred <- predict(bst, newdata = xgboost::xgb.DMatrix(as.matrix(test_list$data)), 
                     outputmargin = TRUE, reshape=TRUE)
     pred <- t(apply(pred, 1, softmax_transform))
-    test_forecasts <- foreach(i = 1:nrow(pred), .combine = "rbind") %do% {
+    test_forecasts <- foreach(i = seq_len(nrow(pred)), .combine = "rbind") %do% {
       pred[i, ] %*% fforma_fit[[i]]$test_forecasts
     }
     
@@ -2103,11 +2103,11 @@ fforma[[3]]$loss_stats
 #                   outputmargin = TRUE, reshape=TRUE)
 #   pred <- t(apply(pred, 1, softmax_transform))
 #   
-#   validation_forecasts <- foreach(i = 1:nrow(pred), .combine = "rbind") %do% {
+#   validation_forecasts <- foreach(i = seq_len(nrow(pred)), .combine = "rbind") %do% {
 #     pred[i, ] %*% set_1[[i]]$validation_forecasts
 #   }
 #   
-#   validation_error <- foreach(i = 1:nrow(pred), .combine = "rbind") %do% {
+#   validation_error <- foreach(i = seq_len(nrow(pred)), .combine = "rbind") %do% {
 #     t(pred[i, ]) %*% unlist(set_1[[i]]$validation_error_mse)
 #   }
 #   

--- a/R/xgboost/demo/interaction_constraints.R
+++ b/R/xgboost/demo/interaction_constraints.R
@@ -31,7 +31,7 @@ treeInteractions <- function(input_tree, input_max_depth){
   # Extract nodes with interactions
   interaction_trees <- trees[!is.na(Split) & !is.na(parent_1), 
                              c('Feature',paste0('parent_feat_',1:(input_max_depth-1))), with=F]
-  interaction_trees_split <- split(interaction_trees, 1:nrow(interaction_trees))
+  interaction_trees_split <- split(interaction_trees, seq_len(nrow(interaction_trees)))
   interaction_list <- lapply(interaction_trees_split, as.character)
 
   # Remove NAs (no parent interaction)
@@ -93,7 +93,7 @@ bst3_interactions <- treeInteractions(bst3_tree, 4)  # interactions still constr
 
 # Show monotonic constraints still apply by checking scores after incrementing V1
 x1 <- sort(unique(x[['V1']]))
-for (i in 1:length(x1)){
+for (i in seq_along(x1)){
   testdata <- copy(x[, -c('V1')])
   testdata[['V1']] <- x1[i]
   testdata <- testdata[, paste0('V',1:10), with=F]


### PR DESCRIPTION
Modernizes legacy loop patterns by replacing `1:length(x)` with `seq_along(x)` and `1:nrow(x)` with `seq_len(nrow(x))`. This native standard prevents unintended `1:0` sequences when objects have zero length, increasing script robustness without adding new dependencies.

---
*PR created automatically by Jules for task [12132287792472469845](https://jules.google.com/task/12132287792472469845) started by @zeyuz35*