### PR TITLE
📦 Binder: remove library call and use explicit namespacing for xgboost

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,13 @@
+## 2024-05-14 - Remove library calls in R directory
+**Learning:** The project's `agents.md` prohibits `library()` or `require()` calls within the `R/` directory. Found multiple instances of `library("reticulate")` and `library("xgboost")`. Wait, there are many `library(...)` calls in `.Rmd` and `.R` files. For a small structural improvement without breaking changes, picking ONE explicit namespace fix in `R/AWS/sagemaker_demo.R` is safe.
+Actually, if `sagemaker_demo.R` has `library(tidyverse)` and `library(stringr)` and `library("reticulate")`, removing just `library("reticulate")` and using explicit namespace for `reticulate::import` is one logical change.
+Wait! I'll replace `library("reticulate")` with explicit `reticulate::import('sagemaker')`.
+
+Actually, wait, I could instead modify `gpu_accelerated.R` to just explicitly use `xgboost::...`.
+But let's look at `R/AWS/sagemaker_demo.R`
+It uses `read_csv`, `filter`, `mutate`, `as.integer`, `select`, `sample_frac`, `anti_join`, `write_csv` (tidyverse functions).
+It uses `str_split` (stringr).
+If I remove `library("reticulate")`, I'll fix the `reticulate` namespace.
+To fix *all* library calls in `R/AWS/sagemaker_demo.R`, I'd need to explicitly namespace all of them, which is slightly more error-prone, but more complete for that file.
+
+Alternatively, `R/xgboost/demo/gpu_accelerated.R` uses `library('xgboost')`, and calls `xgb.DMatrix()`, `xgb.train()`. It's a very simple script, easy to fix. Let's fix `R/xgboost/demo/gpu_accelerated.R`.

--- a/R/xgboost/demo/gpu_accelerated.R
+++ b/R/xgboost/demo/gpu_accelerated.R
@@ -7,7 +7,6 @@
 # https://xgboost.readthedocs.io/en/latest/gpu/index.html
 #
 
-library('xgboost')
 
 # Simulate N x p random matrix with some binomial response dependent on pp columns
 set.seed(111)
@@ -21,8 +20,8 @@ m <- X[, sel] %*% betas - 1 + rnorm(N)
 y <- rbinom(N, 1, plogis(m))
 
 tr <- sample.int(N, N * 0.75)
-dtrain <- xgb.DMatrix(X[tr,], label = y[tr])
-dtest <- xgb.DMatrix(X[-tr,], label = y[-tr])
+dtrain <- xgboost::xgb.DMatrix(X[tr,], label = y[tr])
+dtest <- xgboost::xgb.DMatrix(X[-tr,], label = y[-tr])
 wl <- list(train = dtrain, test = dtest)
 
 # An example of running 'gpu_hist' algorithm
@@ -35,11 +34,11 @@ wl <- list(train = dtrain, test = dtest)
 param <- list(objective = 'reg:logistic', eval_metric = 'auc', subsample = 0.5, nthread = 4,
               max_bin = 64, tree_method = 'gpu_hist')
 pt <- proc.time()
-bst_gpu <- xgb.train(param, dtrain, watchlist = wl, nrounds = 50)
+bst_gpu <- xgboost::xgb.train(param, dtrain, watchlist = wl, nrounds = 50)
 proc.time() - pt
 
 # Compare to the 'hist' algorithm:
 param$tree_method <- 'hist'
 pt <- proc.time()
-bst_hist <- xgb.train(param, dtrain, watchlist = wl, nrounds = 50)
+bst_hist <- xgboost::xgb.train(param, dtrain, watchlist = wl, nrounds = 50)
 proc.time() - pt


### PR DESCRIPTION
Removed prohibited `library('xgboost')` call inside `R/` directory in `R/xgboost/demo/gpu_accelerated.R` and used explicit namespacing `xgboost::` as mandated by `agents.md`.

---
*PR created automatically by Jules for task [1181537152011298344](https://jules.google.com/task/1181537152011298344) started by @zeyuz35*