### PR TITLE
⚡ Bolt: vectorized array slice assignment for LSTM variable importance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Replacing iterative array slicing with direct vectorization
+**Learning:** Found a loop iterating over array dimensions (`for (t in 1:dim(X)[1]) { X[t, 1, index] <- 0 }`) instead of utilizing vectorization (`X[, 1, index] <- 0`).
+**Action:** Replace explicit nested loops iterating over dimension boundaries with direct vectorized slice assignments.

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -1331,9 +1331,7 @@ LSTM_variable_importance <- function(X_array_test, Y_array_test, test_x, lstm_mo
     index <- seq(1, 200, by = 1) + (i - 1)*200
     
     X_array_test_zero <- X_array_test
-    for (t in 1:dim(X_array_test)[1]) {
-      X_array_test_zero[t, 1, index] <- 0
-    }
+    X_array_test_zero[, 1, index] <- 0
 
     original_R2 <- R2(predict(lstm_model, X_array_test), Y_array_test %>% as.vector(), form = "traditional")
 


### PR DESCRIPTION
Replaced explicit nested loop iterating over dimension boundaries (`for (t in 1:dim(X)[1]) { X[t, 1, index] <- 0 }`) with direct vectorized slice assignment (`X[, 1, index] <- 0`) to improve performance.

---
*PR created automatically by Jules for task [13426511701775875852](https://jules.google.com/task/13426511701775875852) started by @zeyuz35*