### PR TITLE
📦 Binder: Remove unused dependencies in umap_play.R

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-06-09 - Remove Unused Dependencies in Exploratory Script
+**Learning:** Found several unused `library()` imports (e.g., `purrr`, `tidyr`, `tsfeatures`, `gganimate`, `sneezy`) in an exploratory script (`R/umap_play.R`).
+**Action:** Remove these unused dependencies to improve codebase hygiene and reduce dependency bloat, especially as `agents.md` emphasizes minimizing external dependencies.

--- a/R/umap_play.R
+++ b/R/umap_play.R
@@ -1,13 +1,7 @@
 library(umap)
-library(purrr)
-library(tidyr)
 library(dplyr)
 library(ggplot2)
 library(Rtsne)
-#devtools::install_github("robjhyndman/tsfeatures")
-library(tsfeatures)
-library(gganimate) # required for printing tours
-library(sneezy)
 final_dataset <- readRDS("~/Dropbox/website/Evaluation-of-Machine-Learning-in-Asset-Pricing/R/final_dataset.rds")
 
 final_dataset_t<-final_dataset%>%select(-rt)


### PR DESCRIPTION
Removes unused library imports (purrr, tidyr, tsfeatures, gganimate, sneezy) from R/umap_play.R to reduce dependency bloat.

---
*PR created automatically by Jules for task [4820941961538126457](https://jules.google.com/task/4820941961538126457) started by @zeyuz35*