### PR TITLE
🛡️ Sentinel: Remove hardcoded rstudio password from AWS templates

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-26 - Hardcoded AWS passwords
+**Vulnerability:** AWS EC2 templates (sagemaker_stack.txt and template1) contained hardcoded default passwords for the rstudio user.
+**Learning:** Hardcoded passwords in infrastructure templates expose instances to unauthorized access if the templates or resulting instances are accessible.
+**Prevention:** Always use secure, dynamically provided parameters with NoEcho: true for passwords in infrastructure-as-code templates.

--- a/R/AWS/sagemaker_stack.txt
+++ b/R/AWS/sagemaker_stack.txt
@@ -1,4 +1,9 @@
 Parameters:
+  RStudioPassword:
+    Description: Password for the rstudio user
+    Type: String
+    NoEcho: true
+    MinLength: 8
   KeyName:
     Description: SSH key pair to use for instance login
     Type: AWS::EC2::KeyPair::KeyName
@@ -93,8 +98,8 @@ Resources:
           sudo apt install r-base
           sudo pip install sagemaker boto3
           sudo R -e "install.packages(c('reticulate', 'curl', 'tidyverse'), repos = 'http://cran.rstudio.com')"
-          sudo adduser rstudio
-          sudo sh -c "echo rstudio | passwd rstudio --stdin"
+          sudo useradd -m rstudio
+          sudo sh -c "echo rstudio:${RStudioPassword} | chpasswd"
           wget https://download2.rstudio.org/rstudio-server-rhel-1.2.5033-x86_64.rpm
           sudo apt install -y rstudio-server-rhel-1.2.5033-x86_64.rpm
           sudo -u rstudio mkdir /home/rstudio/.aws

--- a/R/AWS/template1
+++ b/R/AWS/template1
@@ -1,4 +1,9 @@
 Parameters:
+  RStudioPassword:
+    Description: Password for the rstudio user
+    Type: String
+    NoEcho: true
+    MinLength: 8
   KeyName:
     Description: SSH key pair to use for instance login
     Type: AWS::EC2::KeyPair::KeyName
@@ -94,8 +99,8 @@ Resources:
           sudo ln -s /opt/R/3.6.2/bin/Rscript /usr/local/bin/Rscript
           sudo pip install sagemaker boto3
           sudo R -e "install.packages(c('reticulate', 'readr', 'curl', 'ggplot2', 'dplyr', 'stringr'), repos = 'http://cran.rstudio.com')"
-          sudo adduser rstudio
-          sudo sh -c "echo rstudio | passwd rstudio --stdin"
+          sudo useradd -m rstudio
+          sudo sh -c "echo ${RStudioPassword} | passwd rstudio --stdin"
           wget https://download2.rstudio.org/rstudio-server-rhel-1.1.456-x86_64.rpm
           sudo yum install -y rstudio-server-rhel-1.1.456-x86_64.rpm
           sudo -u rstudio mkdir /home/rstudio/.aws


### PR DESCRIPTION
Removes the hardcoded 'rstudio' password from AWS CloudFormation templates and replaces it with a secure parameter.

---
*PR created automatically by Jules for task [12165866255231660051](https://jules.google.com/task/12165866255231660051) started by @zeyuz35*