### PR TITLE
📦 Binder: Explicit namespacing to remove library calls

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Remove library() calls and use explicit namespacing
+**Learning:** Found scripts with missing dependencies that throw errors when executed because packages like `umap` are missing. Also found a lot of `library()` calls, which violate project guidelines.
+**Action:** Replace `library()` calls with explicit namespacing (e.g. `dplyr::filter`) in R scripts.

--- a/R/AWS/sagemaker_demo.R
+++ b/R/AWS/sagemaker_demo.R
@@ -1,5 +1,4 @@
-library("reticulate")
-sagemaker <- import('sagemaker')
+sagemaker <- reticulate::import('sagemaker')
 session <- sagemaker$Session()
 bucket <- session$default_bucket()
 
@@ -8,44 +7,40 @@ role_arn <- session$expand_role('sagemaker-service-role')
 
 ## Just playing around with dummy data at the moment to get a feel for how Sagemaker works
 
-library(tidyverse)
 data_file <- 'https://archive.ics.uci.edu/ml/machine-learning-databases/abalone/abalone.data'
-abalone <- read_csv(file = data_file, col_names = FALSE)
+abalone <- readr::read_csv(file = data_file, col_names = FALSE)
 names(abalone) <- c('sex', 'length', 'diameter', 'height', 'whole_weight', 'shucked_weight', 'viscera_weight', 'shell_weight', 'rings')
 head(abalone)
 
 abalone$sex <- as.factor(abalone$sex)
 summary(abalone)
 
-ggplot(abalone, aes(x = height, y = rings, color = sex)) + geom_point() + geom_jitter()
+ggplot2::ggplot(abalone, ggplot2::aes(x = height, y = rings, color = sex)) + ggplot2::geom_point() + ggplot2::geom_jitter()
 
 ## Cleaning
 
-abalone <- abalone %>%
-  filter(height != 0)
+abalone <- dplyr::filter(abalone, height != 0)
 
-abalone <- abalone %>%
-  mutate(female = as.integer(ifelse(sex == 'F', 1, 0)),
+abalone <- dplyr::select(
+  dplyr::mutate(abalone,
+         female = as.integer(ifelse(sex == 'F', 1, 0)),
          male = as.integer(ifelse(sex == 'M', 1, 0)),
-         infant = as.integer(ifelse(sex == 'I', 1, 0))) %>%
-  select(-sex)
-abalone <- abalone %>%
-  select(rings:infant, length:shell_weight)
+         infant = as.integer(ifelse(sex == 'I', 1, 0))),
+  -sex)
+abalone <- dplyr::select(abalone, rings:infant, length:shell_weight)
 head(abalone)
 
 ## Train/test split
 
-abalone_train <- abalone %>%
-  sample_frac(size = 0.7)
-abalone <- anti_join(abalone, abalone_train)
-abalone_test <- abalone %>%
-  sample_frac(size = 0.5)
-abalone_valid <- anti_join(abalone, abalone_test)
+abalone_train <- dplyr::sample_frac(abalone, size = 0.7)
+abalone <- dplyr::anti_join(abalone, abalone_train)
+abalone_test <- dplyr::sample_frac(abalone, size = 0.5)
+abalone_valid <- dplyr::anti_join(abalone, abalone_test)
 
 ## Writing datasets to local machine
 
-write_csv(abalone_train, 'abalone_train.csv', col_names = FALSE)
-write_csv(abalone_valid, 'abalone_valid.csv', col_names = FALSE)
+readr::write_csv(abalone_train, 'abalone_train.csv', col_names = FALSE)
+readr::write_csv(abalone_valid, 'abalone_valid.csv', col_names = FALSE)
 
 ## Upload datasets to S3 Bucket
 
@@ -107,9 +102,8 @@ num_predict_rows <- 500
 test_sample <- as.matrix(abalone_test[1:num_predict_rows, ])
 dimnames(test_sample)[[2]] <- NULL
 
-library(stringr)
 predictions <- model_endpoint$predict(test_sample)
-predictions <- str_split(predictions, pattern = ',', simplify = TRUE)
+predictions <- stringr::str_split(predictions, pattern = ',', simplify = TRUE)
 predictions <- as.numeric(predictions)
 
 abalone_test <- cbind(predicted_rings = predictions, 

--- a/R/umap_play.R
+++ b/R/umap_play.R
@@ -1,50 +1,27 @@
-library(umap)
-library(purrr)
-library(tidyr)
-library(dplyr)
-library(ggplot2)
-library(Rtsne)
 #devtools::install_github("robjhyndman/tsfeatures")
-library(tsfeatures)
-library(gganimate) # required for printing tours
-library(sneezy)
 final_dataset <- readRDS("~/Dropbox/website/Evaluation-of-Machine-Learning-in-Asset-Pricing/R/final_dataset.rds")
 
-final_dataset_t<-final_dataset%>%select(-rt)
+final_dataset_t <- dplyr::select(final_dataset, -rt)
 
-row_sample<- sample(2:18048,3000, replace=F)
-col_sample<- sample(1:740,500, replace=F)
+row_sample <- sample(2:18048, 3000, replace=FALSE)
+col_sample <- sample(1:740, 500, replace=FALSE)
 
-data.temp<- final_dataset[row_sample,]
+data.temp <- final_dataset[row_sample, ]
 
 data.temp[is.na(data.temp)] <- 0
 
-data.umap = umap(data.temp)
+data.umap <- umap::umap(data.temp)
 
+d_umap_1 <- as.data.frame(data.umap$layout)
 
-d_umap_1 = as.data.frame(data.umap$layout)  
+ggplot2::ggplot(d_umap_1, ggplot2::aes(x = V1, y = V2)) +
+  ggplot2::geom_point(size = 0.25) +
+  ggplot2::guides(colour = ggplot2::guide_legend(override.aes = list(size = 6)))
 
-ggplot(d_umap_1, aes(x=V1, y=V2)) +  
-  geom_point(size=0.25) +
-  guides(colour=guide_legend(override.aes=list(size=6)))
-
-
-tsne <- Rtsne(data.temp, dims = 2, perplexity=35, verbose=TRUE, max_iter = 2000)
-
+tsne <- Rtsne::Rtsne(data.temp, dims = 2, perplexity = 35, verbose = TRUE, max_iter = 2000)
 
 ## Plotting
-d_tsne_1 = as.data.frame(tsne$Y)  
-ggplot(d_tsne_1, aes(x=V1, y=V2)) +  
-  geom_point(size=0.25) +
-  guides(colour=guide_legend(override.aes=list(size=6)))
-
-
-
-
-
-
-
-
-
-
-
+d_tsne_1 <- as.data.frame(tsne$Y)
+ggplot2::ggplot(d_tsne_1, ggplot2::aes(x = V1, y = V2)) +
+  ggplot2::geom_point(size = 0.25) +
+  ggplot2::guides(colour = ggplot2::guide_legend(override.aes = list(size = 6)))


### PR DESCRIPTION
Replaced library() calls with explicit namespacing and fixed pipeline syntax to avoid global state pollution and dependency issues.

---
*PR created automatically by Jules for task [10198293681691403713](https://jules.google.com/task/10198293681691403713) started by @zeyuz35*