### PR TITLE
⚙️ Modernizer: Replace legacy iterators with seq_len and seq_along in xgboost demo

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,1 +1,3 @@
-## Modernizer Journal
+## 2024-06-11 - Replace legacy iterators with modern safe alternatives
+**Learning:** Legacy iterators like `1:length(x)` and `1:nrow(x)` can cause 1:0 bounds errors when collections are empty.
+**Action:** Replace `1:length(x)` with `seq_along(x)` and `1:nrow(x)` with `seq_len(nrow(x))` for safer code.

--- a/R/xgboost/demo/interaction_constraints.R
+++ b/R/xgboost/demo/interaction_constraints.R
@@ -31,7 +31,7 @@ treeInteractions <- function(input_tree, input_max_depth){
   # Extract nodes with interactions
   interaction_trees <- trees[!is.na(Split) & !is.na(parent_1), 
                              c('Feature',paste0('parent_feat_',1:(input_max_depth-1))), with=F]
-  interaction_trees_split <- split(interaction_trees, 1:nrow(interaction_trees))
+  interaction_trees_split <- split(interaction_trees, seq_len(nrow(interaction_trees)))
   interaction_list <- lapply(interaction_trees_split, as.character)
 
   # Remove NAs (no parent interaction)
@@ -93,7 +93,7 @@ bst3_interactions <- treeInteractions(bst3_tree, 4)  # interactions still constr
 
 # Show monotonic constraints still apply by checking scores after incrementing V1
 x1 <- sort(unique(x[['V1']]))
-for (i in 1:length(x1)){
+for (i in seq_along(x1)){
   testdata <- copy(x[, -c('V1')])
   testdata[['V1']] <- x1[i]
   testdata <- testdata[, paste0('V',1:10), with=F]


### PR DESCRIPTION
Replaces legacy `1:nrow()` and `1:length()` iterators with safer `seq_len()` and `seq_along()` equivalents to prevent out-of-bounds 1:0 errors when iterating over empty collections.

---
*PR created automatically by Jules for task [9356019480352753118](https://jules.google.com/task/9356019480352753118) started by @zeyuz35*