### PR TITLE
⚡ Bolt: replace explicit dimension iteration with vectorized subsetting in LSTM_variable_importance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-13 - Replace explicit nested loops iterating over dimension boundaries with direct vectorized slice assignments
+**Learning:** To maximize performance in R, native array and matrix vectorization should be used over manual iterative subsets. Explicit nested loops iterating over dimension boundaries (e.g., `for (t in 1:dim(X)[1]) { X[t, 1, index] <- 0 }`) can be replaced with direct vectorized slice assignments (e.g., `X[, 1, index] <- 0`).
+**Action:** Always search for explicit iterative subsets using `dim()` or `length()` and replace them with base R vectorized subsets.

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -1331,9 +1331,9 @@ LSTM_variable_importance <- function(X_array_test, Y_array_test, test_x, lstm_mo
     index <- seq(1, 200, by = 1) + (i - 1)*200
     
     X_array_test_zero <- X_array_test
-    for (t in 1:dim(X_array_test)[1]) {
-      X_array_test_zero[t, 1, index] <- 0
-    }
+    X_array_test_zero[, 1, index] <- 0
+
+
 
     original_R2 <- R2(predict(lstm_model, X_array_test), Y_array_test %>% as.vector(), form = "traditional")
 


### PR DESCRIPTION
This PR replaces a manual iterative `for` loop over dimension boundaries `1:dim(X_array_test)[1]` with a faster, base R vectorized array slice assignment `X_array_test_zero[, 1, index] <- 0` in `R/simulation/Simulation Models.Rmd`, significantly improving the performance of the variable importance simulation.

---
*PR created automatically by Jules for task [8021280480556956154](https://jules.google.com/task/8021280480556956154) started by @zeyuz35*