### PR TITLE
⚙️ Modernizer: replace 1:length() and 1:nrow() with seq_along() and seq_len() in iterators

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,1 +1,3 @@
-## Modernizer Journal
+## 2024-06-14 - Replace legacy iterators
+**Learning:** Legacy 1:length() and 1:nrow() patterns can cause 1:0 out-of-bounds errors on empty structures.
+**Action:** Replace with safe seq_along() and seq_len() alternatives.

--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -420,7 +420,7 @@ write.csv(individual_factor_names, file = "individual_factor_names.csv")
 ## This section builds in the macro dataset and egnerates the interaction terms
 interaction_terms <- rep(list(0), length(macro_factor_names))
 
-for (i in 1:length(macro_factor_names)) {
+for (i in seq_along(macro_factor_names)) {
   interaction_terms[[i]] <- paste(macro_factor_names[i], individual_factor_names, sep = ":", collapse = " + ")
 }
 
@@ -908,7 +908,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
   #Initialize List
   RF_model_grid <- rep(list(0), nrow(RF_grid))
   
-  for (i in 1:nrow(RF_grid)) {
+  for (i in seq_len(nrow(RF_grid))) {
     
     RF_model_grid[[i]] <- list(RF_grid = 0, model = 0)
     

--- a/R/empirical_robustness/ff_factors/Real Data.Rmd
+++ b/R/empirical_robustness/ff_factors/Real Data.Rmd
@@ -469,7 +469,7 @@ write.csv(individual_factor_names, file = "individual_factor_names.csv")
 ## This section builds in the macro dataset and egnerates the interaction terms
 interaction_terms <- rep(list(0), length(macro_factor_names))
 
-for (i in 1:length(macro_factor_names)) {
+for (i in seq_along(macro_factor_names)) {
   interaction_terms[[i]] <- paste(macro_factor_names[i], individual_factor_names, sep = ":", collapse = " + ")
 }
 
@@ -961,7 +961,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
   #Initialize List
   RF_model_grid <- rep(list(0), nrow(RF_grid))
   
-  for (i in 1:nrow(RF_grid)) {
+  for (i in seq_len(nrow(RF_grid))) {
     
     RF_model_grid[[i]] <- list(RF_grid = 0, model = 0)
     

--- a/R/empirical_robustness/missing_threshold/Real Data.Rmd
+++ b/R/empirical_robustness/missing_threshold/Real Data.Rmd
@@ -419,7 +419,7 @@ write.csv(individual_factor_names, file = "individual_factor_names.csv")
 ## This section builds in the macro dataset and egnerates the interaction terms
 interaction_terms <- rep(list(0), length(macro_factor_names))
 
-for (i in 1:length(macro_factor_names)) {
+for (i in seq_along(macro_factor_names)) {
   interaction_terms[[i]] <- paste(macro_factor_names[i], individual_factor_names, sep = ":", collapse = " + ")
 }
 
@@ -909,7 +909,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
   #Initialize List
   RF_model_grid <- rep(list(0), nrow(RF_grid))
   
-  for (i in 1:nrow(RF_grid)) {
+  for (i in seq_len(nrow(RF_grid))) {
     
     RF_model_grid[[i]] <- list(RF_grid = 0, model = 0)
     

--- a/R/empirical_robustness/train_valid_1/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_1/Real Data.Rmd
@@ -417,7 +417,7 @@ write.csv(individual_factor_names, file = "individual_factor_names.csv")
 ## This section builds in the macro dataset and egnerates the interaction terms
 interaction_terms <- rep(list(0), length(macro_factor_names))
 
-for (i in 1:length(macro_factor_names)) {
+for (i in seq_along(macro_factor_names)) {
   interaction_terms[[i]] <- paste(macro_factor_names[i], individual_factor_names, sep = ":", collapse = " + ")
 }
 
@@ -906,7 +906,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
   #Initialize List
   RF_model_grid <- rep(list(0), nrow(RF_grid))
   
-  for (i in 1:nrow(RF_grid)) {
+  for (i in seq_len(nrow(RF_grid))) {
     
     RF_model_grid[[i]] <- list(RF_grid = 0, model = 0)
     

--- a/R/empirical_robustness/train_valid_2/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_2/Real Data.Rmd
@@ -419,7 +419,7 @@ write.csv(individual_factor_names, file = "individual_factor_names.csv")
 ## This section builds in the macro dataset and egnerates the interaction terms
 interaction_terms <- rep(list(0), length(macro_factor_names))
 
-for (i in 1:length(macro_factor_names)) {
+for (i in seq_along(macro_factor_names)) {
   interaction_terms[[i]] <- paste(macro_factor_names[i], individual_factor_names, sep = ":", collapse = " + ")
 }
 
@@ -913,7 +913,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
   #Initialize List
   RF_model_grid <- rep(list(0), nrow(RF_grid))
   
-  for (i in 1:nrow(RF_grid)) {
+  for (i in seq_len(nrow(RF_grid))) {
     
     RF_model_grid[[i]] <- list(RF_grid = 0, model = 0)
     

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -424,7 +424,7 @@ ELN_grid <- expand.grid(
 ELN_model_grid <- function(ELN_grid, train_x, train_y, validation_x, validation_y, loss_function, nlambda) {
   ELN_model_grid <- rep(list(0), nrow(ELN_grid))
   
-  for (i in 1:nrow(ELN_grid)) {
+  for (i in seq_len(nrow(ELN_grid))) {
     
     ELN_model_grid[[i]] <- list(ELN_grid = 0, model = 0)
     
@@ -753,7 +753,7 @@ RF_fit_model_grid <- function(f, train, validation, RF_grid, loss_function) {
   #Initialize List
   RF_model_grid <- rep(list(0), nrow(RF_grid))
   
-  for (i in 1:nrow(RF_grid)) {
+  for (i in seq_len(nrow(RF_grid))) {
     
     RF_model_grid[[i]] <- list(RF_grid = 0, model = 0)
     
@@ -1876,7 +1876,7 @@ fforma_errors <- function(fforma_fit, loss_function) {
 # Labels matrix (using the erros matrix)
 
 fforma_labels <- function(errors) {
-  foreach(i = 1:nrow(errors), .combine = "rbind") %dopar% {
+  foreach(i = seq_len(nrow(errors)), .combine = "rbind") %dopar% {
     data.frame(label = which.min(errors[i, ]) - 1)
   }
 }
@@ -1953,7 +1953,7 @@ error_softmax_obj <- function(preds, dtrain) {
 fforma_fit_stats <- function(pooled_panel, timeSlices, loss_function) {
   fforma_fit_stats_list <- rep(list(0), length(timeSlices))
   
-  for (set in 1:length(fforma_fit_stats_list)) {
+  for (set in seq_along(fforma_fit_stats_list)) {
     fforma_fit_stats_list[[set]] <- list(loss_stats = data.frame(train_MAE = 0, train_MSE = 0, 
                                                                  train_RMSE = 0, train_RSquare = 0, 
                                                                  validation_MAE = 0, validation_MSE = 0,
@@ -2010,7 +2010,7 @@ fforma_fit_stats <- function(pooled_panel, timeSlices, loss_function) {
                     outputmargin = TRUE, reshape=TRUE)
     pred <- t(apply(pred, 1, softmax_transform))
 
-    validation_forecasts <- foreach(i = 1:nrow(pred), .combine = "rbind") %do% {
+    validation_forecasts <- foreach(i = seq_len(nrow(pred)), .combine = "rbind") %do% {
       pred[i, ] %*% fforma_fit[[i]]$validation_forecasts
     }
     
@@ -2020,7 +2020,7 @@ fforma_fit_stats <- function(pooled_panel, timeSlices, loss_function) {
     pred <- predict(bst, newdata = xgboost::xgb.DMatrix(as.matrix(test_list$data)), 
                     outputmargin = TRUE, reshape=TRUE)
     pred <- t(apply(pred, 1, softmax_transform))
-    test_forecasts <- foreach(i = 1:nrow(pred), .combine = "rbind") %do% {
+    test_forecasts <- foreach(i = seq_len(nrow(pred)), .combine = "rbind") %do% {
       pred[i, ] %*% fforma_fit[[i]]$test_forecasts
     }
     
@@ -2103,11 +2103,11 @@ fforma[[3]]$loss_stats
 #                   outputmargin = TRUE, reshape=TRUE)
 #   pred <- t(apply(pred, 1, softmax_transform))
 #   
-#   validation_forecasts <- foreach(i = 1:nrow(pred), .combine = "rbind") %do% {
+#   validation_forecasts <- foreach(i = seq_len(nrow(pred)), .combine = "rbind") %do% {
 #     pred[i, ] %*% set_1[[i]]$validation_forecasts
 #   }
 #   
-#   validation_error <- foreach(i = 1:nrow(pred), .combine = "rbind") %do% {
+#   validation_error <- foreach(i = seq_len(nrow(pred)), .combine = "rbind") %do% {
 #     t(pred[i, ]) %*% unlist(set_1[[i]]$validation_error_mse)
 #   }
 #   

--- a/R/xgboost/demo/interaction_constraints.R
+++ b/R/xgboost/demo/interaction_constraints.R
@@ -31,7 +31,7 @@ treeInteractions <- function(input_tree, input_max_depth){
   # Extract nodes with interactions
   interaction_trees <- trees[!is.na(Split) & !is.na(parent_1), 
                              c('Feature',paste0('parent_feat_',1:(input_max_depth-1))), with=F]
-  interaction_trees_split <- split(interaction_trees, 1:nrow(interaction_trees))
+  interaction_trees_split <- split(interaction_trees, seq_len(nrow(interaction_trees)))
   interaction_list <- lapply(interaction_trees_split, as.character)
 
   # Remove NAs (no parent interaction)
@@ -93,7 +93,7 @@ bst3_interactions <- treeInteractions(bst3_tree, 4)  # interactions still constr
 
 # Show monotonic constraints still apply by checking scores after incrementing V1
 x1 <- sort(unique(x[['V1']]))
-for (i in 1:length(x1)){
+for (i in seq_along(x1)){
   testdata <- copy(x[, -c('V1')])
   testdata[['V1']] <- x1[i]
   testdata <- testdata[, paste0('V',1:10), with=F]


### PR DESCRIPTION
Modernized legacy iteration patterns by replacing 1:length() and 1:nrow() with safe seq_along() and seq_len() alternatives to prevent out-of-bounds errors.

---
*PR created automatically by Jules for task [16496318797085025332](https://jules.google.com/task/16496318797085025332) started by @zeyuz35*