### PR TITLE
📦 Binder: remove global library calls and enforce explicit namespacing in R/umap_play.R

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-06-14 - Enforce Explicit Namespacing in R Scripts
+**Learning:** Found R script with multiple global \`library()\` calls which violate package hygiene standards by unnecessarily polluting the global namespace. When converting to explicit namespacing, all associated usages (like \`ggplot2::ggplot\` and \`dplyr::select\`) must be updated to prevent syntax errors.
+**Action:** Replace all \`library()\` calls with explicit \`pkg::function()\` namespace references in script files to adhere to the project's Global State and Side Effects standards.

--- a/R/umap_play.R
+++ b/R/umap_play.R
@@ -1,50 +1,26 @@
-library(umap)
-library(purrr)
-library(tidyr)
-library(dplyr)
-library(ggplot2)
-library(Rtsne)
-#devtools::install_github("robjhyndman/tsfeatures")
-library(tsfeatures)
-library(gganimate) # required for printing tours
-library(sneezy)
 final_dataset <- readRDS("~/Dropbox/website/Evaluation-of-Machine-Learning-in-Asset-Pricing/R/final_dataset.rds")
 
-final_dataset_t<-final_dataset%>%select(-rt)
+final_dataset_t <- dplyr::select(final_dataset, -rt)
 
-row_sample<- sample(2:18048,3000, replace=F)
-col_sample<- sample(1:740,500, replace=F)
+row_sample <- sample(2:18048, 3000, replace=F)
+col_sample <- sample(1:740, 500, replace=F)
 
-data.temp<- final_dataset[row_sample,]
+data.temp <- final_dataset[row_sample,]
 
 data.temp[is.na(data.temp)] <- 0
 
-data.umap = umap(data.temp)
-
+data.umap = umap::umap(data.temp)
 
 d_umap_1 = as.data.frame(data.umap$layout)  
 
-ggplot(d_umap_1, aes(x=V1, y=V2)) +  
-  geom_point(size=0.25) +
-  guides(colour=guide_legend(override.aes=list(size=6)))
+ggplot2::ggplot(d_umap_1, ggplot2::aes(x=V1, y=V2)) +
+  ggplot2::geom_point(size=0.25) +
+  ggplot2::guides(colour=ggplot2::guide_legend(override.aes=list(size=6)))
 
-
-tsne <- Rtsne(data.temp, dims = 2, perplexity=35, verbose=TRUE, max_iter = 2000)
-
+tsne <- Rtsne::Rtsne(data.temp, dims = 2, perplexity=35, verbose=TRUE, max_iter = 2000)
 
 ## Plotting
 d_tsne_1 = as.data.frame(tsne$Y)  
-ggplot(d_tsne_1, aes(x=V1, y=V2)) +  
-  geom_point(size=0.25) +
-  guides(colour=guide_legend(override.aes=list(size=6)))
-
-
-
-
-
-
-
-
-
-
-
+ggplot2::ggplot(d_tsne_1, ggplot2::aes(x=V1, y=V2)) +
+  ggplot2::geom_point(size=0.25) +
+  ggplot2::guides(colour=ggplot2::guide_legend(override.aes=list(size=6)))


### PR DESCRIPTION
Removes global `library()` calls and uses explicit namespacing (e.g. `umap::umap()`, `dplyr::select()`) in `R/umap_play.R` per `agents.md` Global State and Side Effects standards.

---
*PR created automatically by Jules for task [8122354835951748165](https://jules.google.com/task/8122354835951748165) started by @zeyuz35*