### PR TITLE
📦 Binder: remove library imports and use explicit namespacing in umap_play.R

### DIFF
--- a/.jules/binder.md
+++ b/.jules/binder.md
@@ -1,0 +1,3 @@
+## 2024-06-15 - Explicit namespacing and dependency reduction in R scripts
+**Learning:** Found several active exploratory scripts in `R/` that were globally loading multiple packages via `library()` (like `dplyr`, `ggplot2`, etc.) which pollutes the global namespace and violates the project's hygiene standards (as per agents.md).
+**Action:** Removed all `library()` calls in `R/umap_play.R` and replaced them with explicit namespaced calls (e.g. `dplyr::select`, `umap::umap`, `ggplot2::ggplot`, `Rtsne::Rtsne`). Also replaced magrittr pipes with nested functions or base R equivalents where applicable to reduce dependencies.

--- a/R/umap_play.R
+++ b/R/umap_play.R
@@ -1,50 +1,30 @@
-library(umap)
-library(purrr)
-library(tidyr)
-library(dplyr)
-library(ggplot2)
-library(Rtsne)
 #devtools::install_github("robjhyndman/tsfeatures")
-library(tsfeatures)
-library(gganimate) # required for printing tours
-library(sneezy)
 final_dataset <- readRDS("~/Dropbox/website/Evaluation-of-Machine-Learning-in-Asset-Pricing/R/final_dataset.rds")
 
-final_dataset_t<-final_dataset%>%select(-rt)
+final_dataset_t <- dplyr::select(final_dataset, -rt)
 
-row_sample<- sample(2:18048,3000, replace=F)
-col_sample<- sample(1:740,500, replace=F)
+row_sample <- sample(2:18048, 3000, replace=F)
+col_sample <- sample(1:740, 500, replace=F)
 
-data.temp<- final_dataset[row_sample,]
+data.temp <- final_dataset[row_sample,]
 
 data.temp[is.na(data.temp)] <- 0
 
-data.umap = umap(data.temp)
+data.umap <- umap::umap(data.temp)
 
 
-d_umap_1 = as.data.frame(data.umap$layout)  
+d_umap_1 <- as.data.frame(data.umap$layout)
 
-ggplot(d_umap_1, aes(x=V1, y=V2)) +  
-  geom_point(size=0.25) +
-  guides(colour=guide_legend(override.aes=list(size=6)))
+ggplot2::ggplot(d_umap_1, ggplot2::aes(x=V1, y=V2)) +
+  ggplot2::geom_point(size=0.25) +
+  ggplot2::guides(colour=ggplot2::guide_legend(override.aes=list(size=6)))
 
 
-tsne <- Rtsne(data.temp, dims = 2, perplexity=35, verbose=TRUE, max_iter = 2000)
+tsne <- Rtsne::Rtsne(data.temp, dims = 2, perplexity=35, verbose=TRUE, max_iter = 2000)
 
 
 ## Plotting
-d_tsne_1 = as.data.frame(tsne$Y)  
-ggplot(d_tsne_1, aes(x=V1, y=V2)) +  
-  geom_point(size=0.25) +
-  guides(colour=guide_legend(override.aes=list(size=6)))
-
-
-
-
-
-
-
-
-
-
-
+d_tsne_1 <- as.data.frame(tsne$Y)
+ggplot2::ggplot(d_tsne_1, ggplot2::aes(x=V1, y=V2)) +
+  ggplot2::geom_point(size=0.25) +
+  ggplot2::guides(colour=ggplot2::guide_legend(override.aes=list(size=6)))


### PR DESCRIPTION
Removes global `library()` calls in `R/umap_play.R` and implements explicit namespacing (e.g., `pkg::function()`) to prevent global namespace pollution and adhere to package hygiene standards.

---
*PR created automatically by Jules for task [11481518071224272418](https://jules.google.com/task/11481518071224272418) started by @zeyuz35*