### PR TITLE
⚙️ Modernizer: Vectorize LSTM slice assignment

### DIFF
--- a/.jules/modernizer.md
+++ b/.jules/modernizer.md
@@ -1,1 +1,4 @@
-## Modernizer Journal
+## 2024-06-15 - Vectorizing manual slice assignments in LSTM variable importance
+
+**Learning:** R native vectorized subsetting is both cleaner and faster than a `for` loop over dimensions (e.g. `X[t, 1, index] <- 0` in a `for` loop over `t` vs `X[, 1, index] <- 0`).
+**Action:** Replace `for (t in 1:dim(X_array_test)[1]) { X_array_test_zero[t, 1, index] <- 0 }` with `X_array_test_zero[, 1, index] <- 0`.

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -1331,9 +1331,9 @@ LSTM_variable_importance <- function(X_array_test, Y_array_test, test_x, lstm_mo
     index <- seq(1, 200, by = 1) + (i - 1)*200
     
     X_array_test_zero <- X_array_test
-    for (t in 1:dim(X_array_test)[1]) {
-      X_array_test_zero[t, 1, index] <- 0
-    }
+    X_array_test_zero[, 1, index] <- 0
+
+
 
     original_R2 <- R2(predict(lstm_model, X_array_test), Y_array_test %>% as.vector(), form = "traditional")
 


### PR DESCRIPTION
Refactored the slow `for` loop over `dim(X_array_test)[1]` inside `LSTM_variable_importance` to use native R vectorized slice assignment `X_array_test_zero[, 1, index] <- 0`, which improves performance while maintaining clarity.

---
*PR created automatically by Jules for task [8762015722788640250](https://jules.google.com/task/8762015722788640250) started by @zeyuz35*