### PR TITLE
🗃️ Curator: fix type instability caused by scale() coercing data.frames to matrices

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Preserving DataFrames During scale()
+**Learning:** In R, the `scale()` function coerces `data.frame` objects into `matrix` objects while returning the scaled values. This causes a silent type instability when subsequent code expects a `data.frame` (e.g., when binding with other dataframes, or when predicting with certain models that require dataframe inputs rather than matrices).
+**Action:** Always wrap the output of `scale()` with `as.data.frame()` if the input was a `data.frame` and the rest of the pipeline expects a `data.frame`. Ensure that any `scale()` attributes, such as `scaled:center` and `scaled:scale`, are extracted directly from the intermediate scaled matrix *before* it is coerced to a dataframe, as coercion drops those specific attributes.

--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -324,8 +324,8 @@ cross_section_normalize <- function(dataset) {
     #            )
     #   )
     
-    dataset_cross_section_x_norm <- scale(dataset_cross_section_x, center = FALSE, 
-                                          scale = colSums(dataset_cross_section_x))
+    dataset_cross_section_x_norm <- as.data.frame(scale(dataset_cross_section_x, center = FALSE,
+                                          scale = colSums(dataset_cross_section_x)))
     
     colnames(dataset_cross_section_x_norm) <- colnames(dataset_cross_section_x)
     
@@ -1093,17 +1093,18 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
       filter(time %in% timeSlices[[set]]$test)
       
     train_x <- train[4:ncol(train)]
-    train_x <- scale(train_x)
-    col_means_train <- attr(train_x, "scaled:center") 
-    col_stddevs_train <- attr(train_x, "scaled:scale")
+    train_x_scaled <- scale(train_x)
+    col_means_train <- attr(train_x_scaled, "scaled:center")
+    col_stddevs_train <- attr(train_x_scaled, "scaled:scale")
+    train_x <- as.data.frame(train_x_scaled)
     train_y <- train$rt
     
     validation_x <- validation[4:ncol(validation)]
-    validation_x <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x <- as.data.frame(scale(validation_x, center = col_means_train, scale = col_stddevs_train))
     validation_y <- validation$rt
       
     test_x <- test[4:ncol(test)]
-    test_x <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x <- as.data.frame(scale(test_x, center = col_means_train, scale = col_stddevs_train))
     test_y <- test$rt
       
     # Fit the model

--- a/R/empirical_robustness/ff_factors/Real Data.Rmd
+++ b/R/empirical_robustness/ff_factors/Real Data.Rmd
@@ -330,8 +330,8 @@ cross_section_normalize <- function(dataset) {
     #            )
     #   )
     
-    dataset_cross_section_x_norm <- scale(dataset_cross_section_x, center = FALSE, 
-                                          scale = colSums(dataset_cross_section_x))
+    dataset_cross_section_x_norm <- as.data.frame(scale(dataset_cross_section_x, center = FALSE,
+                                          scale = colSums(dataset_cross_section_x)))
     
     colnames(dataset_cross_section_x_norm) <- colnames(dataset_cross_section_x)
     
@@ -1144,17 +1144,18 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
       filter(time %in% timeSlices[[set]]$test)
       
     train_x <- train[4:ncol(train)]
-    train_x <- scale(train_x)
-    col_means_train <- attr(train_x, "scaled:center") 
-    col_stddevs_train <- attr(train_x, "scaled:scale")
+    train_x_scaled <- scale(train_x)
+    col_means_train <- attr(train_x_scaled, "scaled:center")
+    col_stddevs_train <- attr(train_x_scaled, "scaled:scale")
+    train_x <- as.data.frame(train_x_scaled)
     train_y <- train$rt
     
     validation_x <- validation[4:ncol(validation)]
-    validation_x <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x <- as.data.frame(scale(validation_x, center = col_means_train, scale = col_stddevs_train))
     validation_y <- validation$rt
       
     test_x <- test[4:ncol(test)]
-    test_x <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x <- as.data.frame(scale(test_x, center = col_means_train, scale = col_stddevs_train))
     test_y <- test$rt
       
     # Fit the model

--- a/R/empirical_robustness/missing_threshold/Real Data.Rmd
+++ b/R/empirical_robustness/missing_threshold/Real Data.Rmd
@@ -323,8 +323,8 @@ cross_section_normalize <- function(dataset) {
     #            )
     #   )
     
-    dataset_cross_section_x_norm <- scale(dataset_cross_section_x, center = FALSE, 
-                                          scale = colSums(dataset_cross_section_x))
+    dataset_cross_section_x_norm <- as.data.frame(scale(dataset_cross_section_x, center = FALSE,
+                                          scale = colSums(dataset_cross_section_x)))
     
     colnames(dataset_cross_section_x_norm) <- colnames(dataset_cross_section_x)
     
@@ -1094,17 +1094,18 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
       filter(time %in% timeSlices[[set]]$test)
       
     train_x <- train[4:ncol(train)]
-    train_x <- scale(train_x)
-    col_means_train <- attr(train_x, "scaled:center") 
-    col_stddevs_train <- attr(train_x, "scaled:scale")
+    train_x_scaled <- scale(train_x)
+    col_means_train <- attr(train_x_scaled, "scaled:center")
+    col_stddevs_train <- attr(train_x_scaled, "scaled:scale")
+    train_x <- as.data.frame(train_x_scaled)
     train_y <- train$rt
     
     validation_x <- validation[4:ncol(validation)]
-    validation_x <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x <- as.data.frame(scale(validation_x, center = col_means_train, scale = col_stddevs_train))
     validation_y <- validation$rt
       
     test_x <- test[4:ncol(test)]
-    test_x <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x <- as.data.frame(scale(test_x, center = col_means_train, scale = col_stddevs_train))
     test_y <- test$rt
       
     # Fit the model

--- a/R/empirical_robustness/train_valid_1/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_1/Real Data.Rmd
@@ -321,8 +321,8 @@ cross_section_normalize <- function(dataset) {
     #            )
     #   )
     
-    dataset_cross_section_x_norm <- scale(dataset_cross_section_x, center = FALSE, 
-                                          scale = colSums(dataset_cross_section_x))
+    dataset_cross_section_x_norm <- as.data.frame(scale(dataset_cross_section_x, center = FALSE,
+                                          scale = colSums(dataset_cross_section_x)))
     
     colnames(dataset_cross_section_x_norm) <- colnames(dataset_cross_section_x)
     
@@ -1089,17 +1089,18 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
       filter(time %in% timeSlices[[set]]$test)
       
     train_x <- train[4:ncol(train)]
-    train_x <- scale(train_x)
-    col_means_train <- attr(train_x, "scaled:center") 
-    col_stddevs_train <- attr(train_x, "scaled:scale")
+    train_x_scaled <- scale(train_x)
+    col_means_train <- attr(train_x_scaled, "scaled:center")
+    col_stddevs_train <- attr(train_x_scaled, "scaled:scale")
+    train_x <- as.data.frame(train_x_scaled)
     train_y <- train$rt
     
     validation_x <- validation[4:ncol(validation)]
-    validation_x <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x <- as.data.frame(scale(validation_x, center = col_means_train, scale = col_stddevs_train))
     validation_y <- validation$rt
       
     test_x <- test[4:ncol(test)]
-    test_x <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x <- as.data.frame(scale(test_x, center = col_means_train, scale = col_stddevs_train))
     test_y <- test$rt
       
     # Fit the model

--- a/R/empirical_robustness/train_valid_2/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_2/Real Data.Rmd
@@ -323,8 +323,8 @@ cross_section_normalize <- function(dataset) {
     #            )
     #   )
     
-    dataset_cross_section_x_norm <- scale(dataset_cross_section_x, center = FALSE, 
-                                          scale = colSums(dataset_cross_section_x))
+    dataset_cross_section_x_norm <- as.data.frame(scale(dataset_cross_section_x, center = FALSE,
+                                          scale = colSums(dataset_cross_section_x)))
     
     colnames(dataset_cross_section_x_norm) <- colnames(dataset_cross_section_x)
     
@@ -1096,17 +1096,18 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
       filter(time %in% timeSlices[[set]]$test)
       
     train_x <- train[4:ncol(train)]
-    train_x <- scale(train_x)
-    col_means_train <- attr(train_x, "scaled:center") 
-    col_stddevs_train <- attr(train_x, "scaled:scale")
+    train_x_scaled <- scale(train_x)
+    col_means_train <- attr(train_x_scaled, "scaled:center")
+    col_stddevs_train <- attr(train_x_scaled, "scaled:scale")
+    train_x <- as.data.frame(train_x_scaled)
     train_y <- train$rt
     
     validation_x <- validation[4:ncol(validation)]
-    validation_x <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x <- as.data.frame(scale(validation_x, center = col_means_train, scale = col_stddevs_train))
     validation_y <- validation$rt
       
     test_x <- test[4:ncol(test)]
-    test_x <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x <- as.data.frame(scale(test_x, center = col_means_train, scale = col_stddevs_train))
     test_y <- test$rt
       
     # Fit the model

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -969,17 +969,18 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
       filter(time %in% timeSlices[[set]]$test)
       
     train_x <- train[4:ncol(train)]
-    train_x <- scale(train_x)
-    col_means_train <- attr(train_x, "scaled:center") 
-    col_stddevs_train <- attr(train_x, "scaled:scale")
+    train_x_scaled <- scale(train_x)
+    col_means_train <- attr(train_x_scaled, "scaled:center")
+    col_stddevs_train <- attr(train_x_scaled, "scaled:scale")
+    train_x <- as.data.frame(train_x_scaled)
     train_y <- train$rt
     
     validation_x <- validation[4:ncol(validation)]
-    validation_x <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x <- as.data.frame(scale(validation_x, center = col_means_train, scale = col_stddevs_train))
     validation_y <- validation$rt
       
     test_x <- test[4:ncol(test)]
-    test_x <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x <- as.data.frame(scale(test_x, center = col_means_train, scale = col_stddevs_train))
     test_y <- test$rt
       
     # Fit the model
@@ -1379,19 +1380,20 @@ LSTM_fit_stats <- function(pooled_panel, timeSlices, loss_function, batch_size, 
       
     train_x <- train %>%
       dplyr::select(-rt, -stock, -time)
-    train_x <- scale(train_x)
-    col_means_train <- attr(train_x, "scaled:center") 
-    col_stddevs_train <- attr(train_x, "scaled:scale")
+    train_x_scaled <- scale(train_x)
+    col_means_train <- attr(train_x_scaled, "scaled:center")
+    col_stddevs_train <- attr(train_x_scaled, "scaled:scale")
+    train_x <- as.data.frame(train_x_scaled)
     train_y <- train$rt
     
     validation_x <- validation %>%
       dplyr::select(-rt, -stock, -time)
-    validation_x <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x <- as.data.frame(scale(validation_x, center = col_means_train, scale = col_stddevs_train))
     validation_y <- validation$rt
       
     test_x <- test %>%
       dplyr::select(-rt, -stock, -time)
-    test_x <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x <- as.data.frame(scale(test_x, center = col_means_train, scale = col_stddevs_train))
     test_y <- test$rt
     
     pooled_panel_trunc <- rbind(


### PR DESCRIPTION
Wrapped scale() outputs with as.data.frame() to preserve dataframe structure, extracting attributes beforehand.

---
*PR created automatically by Jules for task [13215750594046819338](https://jules.google.com/task/13215750594046819338) started by @zeyuz35*