### PR TITLE
⚡ Bolt: Vectorize array slicing in variable importance routine

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-16 - Vectorize Array Slicing
+**Learning:** Manual loops that iterate over an entire array dimension to assign values (e.g., `for (t in 1:dim(X)[1]) { X[t, 1, index] <- 0 }`) are slower than direct vectorized slice assignments in R.
+**Action:** Use native R vectorization (e.g., `X[, 1, index] <- 0`) to modify whole slices of arrays or matrices to improve execution speed, particularly inside computationally intensive loops.

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -1331,9 +1331,9 @@ LSTM_variable_importance <- function(X_array_test, Y_array_test, test_x, lstm_mo
     index <- seq(1, 200, by = 1) + (i - 1)*200
     
     X_array_test_zero <- X_array_test
-    for (t in 1:dim(X_array_test)[1]) {
-      X_array_test_zero[t, 1, index] <- 0
-    }
+    # Bolt: Replaced slow manual `for (t in ...)` loop with native vectorized array slice
+    # assignment to significantly improve execution speed within the inner foreach loop.
+    X_array_test_zero[, 1, index] <- 0
 
     original_R2 <- R2(predict(lstm_model, X_array_test), Y_array_test %>% as.vector(), form = "traditional")
 


### PR DESCRIPTION
Replaces a slow manual loop iterating over the first dimension of an array with a native vectorized slice assignment (`X[, 1, index] <- 0`). This improves execution speed within the computationally intensive LSTM variable importance function.

---
*PR created automatically by Jules for task [6821651315481127184](https://jules.google.com/task/6821651315481127184) started by @zeyuz35*