### PR TITLE
📝 Docent: Refine informal language in simulation model runner comments

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2024-06-18 - Remove informal language in comments
+**Learning:** Found comments containing informal and non-professional language (e.g. "because it's stupid", "don't want to fit").
+**Action:** Replaced these instances with formal, terse, and professional alternatives in `R/simulation/Simulation Models_run.Rmd` as an initial, safe documentation and style improvement that aligns with the Docent persona, ensuring zero functional impact since they are comments.

--- a/R/simulation/Simulation Models_run.Rmd
+++ b/R/simulation/Simulation Models_run.Rmd
@@ -56,7 +56,7 @@ batch_process_range <- c(1:10)
 
 fit_all_models <- function(dataset_list, batch_process_range,
                            # Logical arguments specifying which models you want to fit
-                           # This is useful if you don't want to fit some of the most intensive methods such as RF and Neural Networks
+                           # This is useful to exclude computationally intensive methods such as RF and Neural Networks.
                            LM, ELN, RF, NNet) {
   # Initialize List
   simulation_results_list <- rep(list(0), length(batch_process_range))
@@ -119,7 +119,7 @@ fit_all_models <- function(dataset_list, batch_process_range,
       
     if (NNet == 1) {
       # Neural Networks
-      # Commented for now because honours lab computers don't have keras/tensorflow
+      # Commented out because lab computers lack keras/tensorflow.
       
       batch_size <- 128
       patience <- 40
@@ -754,7 +754,7 @@ combine_DeepAR_results_list <- function(normal_list, deepar_list15, deepar_list6
 }
 
 ## nosv_0
-## Don't bother with this design because it's stupid, and was only done just to replicate Gu's experiments
+## Exclude this design; it is retained solely to replicate the experiments by Gu et al.
 # g1_A1_nosv_0_results_all <- g1_A1_nosv_0_results %>% 
 #   combine_RF_results_list(g1_A1_nosv_0_RF_results) %>%
 #   combine_NN_results_list(g1_A1_nosv_0_NN_results15, g1_A1_nosv_0_NN_results610) %>%


### PR DESCRIPTION
This PR replaces informal and non-professional language (e.g. 'because it's stupid', 'don't want to fit') with formal, terse, and professional alternatives in the R/simulation/Simulation Models_run.Rmd script. It also includes adding a tracking insight in .jules/docent.md.

---
*PR created automatically by Jules for task [5848742915421023398](https://jules.google.com/task/5848742915421023398) started by @zeyuz35*