### PR TITLE
⚡ Bolt: vectorized array slice assignment in LSTM variable importance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Vectorized array slice assignment in LSTM variable importance
+**Learning:** Manual loops that iterate over an entire dimension of an array (e.g., `for (t in 1:dim(X_array_test)[1]) { X_array_test_zero[t, 1, index] <- 0 }`) can be replaced with direct native vectorized slice assignments (`X_array_test_zero[, 1, index] <- 0`).
+**Action:** Replace the loop with the vectorized equivalent.

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -1331,9 +1331,7 @@ LSTM_variable_importance <- function(X_array_test, Y_array_test, test_x, lstm_mo
     index <- seq(1, 200, by = 1) + (i - 1)*200
     
     X_array_test_zero <- X_array_test
-    for (t in 1:dim(X_array_test)[1]) {
-      X_array_test_zero[t, 1, index] <- 0
-    }
+    X_array_test_zero[, 1, index] <- 0
 
     original_R2 <- R2(predict(lstm_model, X_array_test), Y_array_test %>% as.vector(), form = "traditional")
 


### PR DESCRIPTION
Vectorize array slice assignment to avoid loop over `dim(X)[1]`

---
*PR created automatically by Jules for task [8938547716619603017](https://jules.google.com/task/8938547716619603017) started by @zeyuz35*