### PR TITLE
🗃️ Curator: Explicit preservation of scaled matrix attributes

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## $(date +%Y-%m-%d) - Data Integrity with scale() and attributes
+**Learning:** In R, the `scale()` function converts a `data.frame` to a `matrix` and adds `scaled:center` and `scaled:scale` attributes to it. Previously, the code just extracted the attributes assuming the matrix was fine to keep, but when doing `dataset_cross_section_x_norm <- as.data.frame(dataset_cross_section_x_norm_mat)` or later assigning back into a dataframe structure, the attributes are stripped.
+**Action:** When extracting or keeping `scaled:center` and `scaled:scale` attributes, we must explicitly preserve them when converting the matrix returned by `scale()` back into a `data.frame`.

--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -324,8 +324,11 @@ cross_section_normalize <- function(dataset) {
     #            )
     #   )
     
-    dataset_cross_section_x_norm <- scale(dataset_cross_section_x, center = FALSE, 
+    dataset_cross_section_x_norm_mat <- scale(dataset_cross_section_x, center = FALSE,
                                           scale = colSums(dataset_cross_section_x))
+    dataset_cross_section_x_norm <- as.data.frame(dataset_cross_section_x_norm_mat)
+    attr(dataset_cross_section_x_norm, 'scaled:center') <- attr(dataset_cross_section_x_norm_mat, 'scaled:center')
+    attr(dataset_cross_section_x_norm, 'scaled:scale') <- attr(dataset_cross_section_x_norm_mat, 'scaled:scale')
     
     colnames(dataset_cross_section_x_norm) <- colnames(dataset_cross_section_x)
     
@@ -1093,17 +1096,26 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
       filter(time %in% timeSlices[[set]]$test)
       
     train_x <- train[4:ncol(train)]
-    train_x <- scale(train_x)
+    train_x_mat <- scale(train_x)
+    train_x <- as.data.frame(train_x_mat)
+    attr(train_x, 'scaled:center') <- attr(train_x_mat, 'scaled:center')
+    attr(train_x, 'scaled:scale') <- attr(train_x_mat, 'scaled:scale')
     col_means_train <- attr(train_x, "scaled:center") 
     col_stddevs_train <- attr(train_x, "scaled:scale")
     train_y <- train$rt
     
     validation_x <- validation[4:ncol(validation)]
-    validation_x <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x_mat <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x <- as.data.frame(validation_x_mat)
+    attr(validation_x, 'scaled:center') <- attr(validation_x_mat, 'scaled:center')
+    attr(validation_x, 'scaled:scale') <- attr(validation_x_mat, 'scaled:scale')
     validation_y <- validation$rt
       
     test_x <- test[4:ncol(test)]
-    test_x <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x_mat <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x <- as.data.frame(test_x_mat)
+    attr(test_x, 'scaled:center') <- attr(test_x_mat, 'scaled:center')
+    attr(test_x, 'scaled:scale') <- attr(test_x_mat, 'scaled:scale')
     test_y <- test$rt
       
     # Fit the model

--- a/R/empirical_robustness/ff_factors/Real Data.Rmd
+++ b/R/empirical_robustness/ff_factors/Real Data.Rmd
@@ -330,8 +330,11 @@ cross_section_normalize <- function(dataset) {
     #            )
     #   )
     
-    dataset_cross_section_x_norm <- scale(dataset_cross_section_x, center = FALSE, 
+    dataset_cross_section_x_norm_mat <- scale(dataset_cross_section_x, center = FALSE,
                                           scale = colSums(dataset_cross_section_x))
+    dataset_cross_section_x_norm <- as.data.frame(dataset_cross_section_x_norm_mat)
+    attr(dataset_cross_section_x_norm, 'scaled:center') <- attr(dataset_cross_section_x_norm_mat, 'scaled:center')
+    attr(dataset_cross_section_x_norm, 'scaled:scale') <- attr(dataset_cross_section_x_norm_mat, 'scaled:scale')
     
     colnames(dataset_cross_section_x_norm) <- colnames(dataset_cross_section_x)
     
@@ -1144,17 +1147,26 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
       filter(time %in% timeSlices[[set]]$test)
       
     train_x <- train[4:ncol(train)]
-    train_x <- scale(train_x)
+    train_x_mat <- scale(train_x)
+    train_x <- as.data.frame(train_x_mat)
+    attr(train_x, 'scaled:center') <- attr(train_x_mat, 'scaled:center')
+    attr(train_x, 'scaled:scale') <- attr(train_x_mat, 'scaled:scale')
     col_means_train <- attr(train_x, "scaled:center") 
     col_stddevs_train <- attr(train_x, "scaled:scale")
     train_y <- train$rt
     
     validation_x <- validation[4:ncol(validation)]
-    validation_x <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x_mat <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x <- as.data.frame(validation_x_mat)
+    attr(validation_x, 'scaled:center') <- attr(validation_x_mat, 'scaled:center')
+    attr(validation_x, 'scaled:scale') <- attr(validation_x_mat, 'scaled:scale')
     validation_y <- validation$rt
       
     test_x <- test[4:ncol(test)]
-    test_x <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x_mat <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x <- as.data.frame(test_x_mat)
+    attr(test_x, 'scaled:center') <- attr(test_x_mat, 'scaled:center')
+    attr(test_x, 'scaled:scale') <- attr(test_x_mat, 'scaled:scale')
     test_y <- test$rt
       
     # Fit the model

--- a/R/empirical_robustness/missing_threshold/Real Data.Rmd
+++ b/R/empirical_robustness/missing_threshold/Real Data.Rmd
@@ -323,8 +323,11 @@ cross_section_normalize <- function(dataset) {
     #            )
     #   )
     
-    dataset_cross_section_x_norm <- scale(dataset_cross_section_x, center = FALSE, 
+    dataset_cross_section_x_norm_mat <- scale(dataset_cross_section_x, center = FALSE,
                                           scale = colSums(dataset_cross_section_x))
+    dataset_cross_section_x_norm <- as.data.frame(dataset_cross_section_x_norm_mat)
+    attr(dataset_cross_section_x_norm, 'scaled:center') <- attr(dataset_cross_section_x_norm_mat, 'scaled:center')
+    attr(dataset_cross_section_x_norm, 'scaled:scale') <- attr(dataset_cross_section_x_norm_mat, 'scaled:scale')
     
     colnames(dataset_cross_section_x_norm) <- colnames(dataset_cross_section_x)
     
@@ -1094,17 +1097,26 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
       filter(time %in% timeSlices[[set]]$test)
       
     train_x <- train[4:ncol(train)]
-    train_x <- scale(train_x)
+    train_x_mat <- scale(train_x)
+    train_x <- as.data.frame(train_x_mat)
+    attr(train_x, 'scaled:center') <- attr(train_x_mat, 'scaled:center')
+    attr(train_x, 'scaled:scale') <- attr(train_x_mat, 'scaled:scale')
     col_means_train <- attr(train_x, "scaled:center") 
     col_stddevs_train <- attr(train_x, "scaled:scale")
     train_y <- train$rt
     
     validation_x <- validation[4:ncol(validation)]
-    validation_x <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x_mat <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x <- as.data.frame(validation_x_mat)
+    attr(validation_x, 'scaled:center') <- attr(validation_x_mat, 'scaled:center')
+    attr(validation_x, 'scaled:scale') <- attr(validation_x_mat, 'scaled:scale')
     validation_y <- validation$rt
       
     test_x <- test[4:ncol(test)]
-    test_x <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x_mat <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x <- as.data.frame(test_x_mat)
+    attr(test_x, 'scaled:center') <- attr(test_x_mat, 'scaled:center')
+    attr(test_x, 'scaled:scale') <- attr(test_x_mat, 'scaled:scale')
     test_y <- test$rt
       
     # Fit the model

--- a/R/empirical_robustness/train_valid_1/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_1/Real Data.Rmd
@@ -321,8 +321,11 @@ cross_section_normalize <- function(dataset) {
     #            )
     #   )
     
-    dataset_cross_section_x_norm <- scale(dataset_cross_section_x, center = FALSE, 
+    dataset_cross_section_x_norm_mat <- scale(dataset_cross_section_x, center = FALSE,
                                           scale = colSums(dataset_cross_section_x))
+    dataset_cross_section_x_norm <- as.data.frame(dataset_cross_section_x_norm_mat)
+    attr(dataset_cross_section_x_norm, 'scaled:center') <- attr(dataset_cross_section_x_norm_mat, 'scaled:center')
+    attr(dataset_cross_section_x_norm, 'scaled:scale') <- attr(dataset_cross_section_x_norm_mat, 'scaled:scale')
     
     colnames(dataset_cross_section_x_norm) <- colnames(dataset_cross_section_x)
     
@@ -1089,17 +1092,26 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
       filter(time %in% timeSlices[[set]]$test)
       
     train_x <- train[4:ncol(train)]
-    train_x <- scale(train_x)
+    train_x_mat <- scale(train_x)
+    train_x <- as.data.frame(train_x_mat)
+    attr(train_x, 'scaled:center') <- attr(train_x_mat, 'scaled:center')
+    attr(train_x, 'scaled:scale') <- attr(train_x_mat, 'scaled:scale')
     col_means_train <- attr(train_x, "scaled:center") 
     col_stddevs_train <- attr(train_x, "scaled:scale")
     train_y <- train$rt
     
     validation_x <- validation[4:ncol(validation)]
-    validation_x <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x_mat <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x <- as.data.frame(validation_x_mat)
+    attr(validation_x, 'scaled:center') <- attr(validation_x_mat, 'scaled:center')
+    attr(validation_x, 'scaled:scale') <- attr(validation_x_mat, 'scaled:scale')
     validation_y <- validation$rt
       
     test_x <- test[4:ncol(test)]
-    test_x <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x_mat <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x <- as.data.frame(test_x_mat)
+    attr(test_x, 'scaled:center') <- attr(test_x_mat, 'scaled:center')
+    attr(test_x, 'scaled:scale') <- attr(test_x_mat, 'scaled:scale')
     test_y <- test$rt
       
     # Fit the model

--- a/R/empirical_robustness/train_valid_2/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_2/Real Data.Rmd
@@ -323,8 +323,11 @@ cross_section_normalize <- function(dataset) {
     #            )
     #   )
     
-    dataset_cross_section_x_norm <- scale(dataset_cross_section_x, center = FALSE, 
+    dataset_cross_section_x_norm_mat <- scale(dataset_cross_section_x, center = FALSE,
                                           scale = colSums(dataset_cross_section_x))
+    dataset_cross_section_x_norm <- as.data.frame(dataset_cross_section_x_norm_mat)
+    attr(dataset_cross_section_x_norm, 'scaled:center') <- attr(dataset_cross_section_x_norm_mat, 'scaled:center')
+    attr(dataset_cross_section_x_norm, 'scaled:scale') <- attr(dataset_cross_section_x_norm_mat, 'scaled:scale')
     
     colnames(dataset_cross_section_x_norm) <- colnames(dataset_cross_section_x)
     
@@ -1096,17 +1099,26 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
       filter(time %in% timeSlices[[set]]$test)
       
     train_x <- train[4:ncol(train)]
-    train_x <- scale(train_x)
+    train_x_mat <- scale(train_x)
+    train_x <- as.data.frame(train_x_mat)
+    attr(train_x, 'scaled:center') <- attr(train_x_mat, 'scaled:center')
+    attr(train_x, 'scaled:scale') <- attr(train_x_mat, 'scaled:scale')
     col_means_train <- attr(train_x, "scaled:center") 
     col_stddevs_train <- attr(train_x, "scaled:scale")
     train_y <- train$rt
     
     validation_x <- validation[4:ncol(validation)]
-    validation_x <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x_mat <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x <- as.data.frame(validation_x_mat)
+    attr(validation_x, 'scaled:center') <- attr(validation_x_mat, 'scaled:center')
+    attr(validation_x, 'scaled:scale') <- attr(validation_x_mat, 'scaled:scale')
     validation_y <- validation$rt
       
     test_x <- test[4:ncol(test)]
-    test_x <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x_mat <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x <- as.data.frame(test_x_mat)
+    attr(test_x, 'scaled:center') <- attr(test_x_mat, 'scaled:center')
+    attr(test_x, 'scaled:scale') <- attr(test_x_mat, 'scaled:scale')
     test_y <- test$rt
       
     # Fit the model

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -969,17 +969,26 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
       filter(time %in% timeSlices[[set]]$test)
       
     train_x <- train[4:ncol(train)]
-    train_x <- scale(train_x)
+    train_x_mat <- scale(train_x)
+    train_x <- as.data.frame(train_x_mat)
+    attr(train_x, 'scaled:center') <- attr(train_x_mat, 'scaled:center')
+    attr(train_x, 'scaled:scale') <- attr(train_x_mat, 'scaled:scale')
     col_means_train <- attr(train_x, "scaled:center") 
     col_stddevs_train <- attr(train_x, "scaled:scale")
     train_y <- train$rt
     
     validation_x <- validation[4:ncol(validation)]
-    validation_x <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x_mat <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x <- as.data.frame(validation_x_mat)
+    attr(validation_x, 'scaled:center') <- attr(validation_x_mat, 'scaled:center')
+    attr(validation_x, 'scaled:scale') <- attr(validation_x_mat, 'scaled:scale')
     validation_y <- validation$rt
       
     test_x <- test[4:ncol(test)]
-    test_x <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x_mat <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x <- as.data.frame(test_x_mat)
+    attr(test_x, 'scaled:center') <- attr(test_x_mat, 'scaled:center')
+    attr(test_x, 'scaled:scale') <- attr(test_x_mat, 'scaled:scale')
     test_y <- test$rt
       
     # Fit the model
@@ -1379,19 +1388,28 @@ LSTM_fit_stats <- function(pooled_panel, timeSlices, loss_function, batch_size, 
       
     train_x <- train %>%
       dplyr::select(-rt, -stock, -time)
-    train_x <- scale(train_x)
+    train_x_mat <- scale(train_x)
+    train_x <- as.data.frame(train_x_mat)
+    attr(train_x, 'scaled:center') <- attr(train_x_mat, 'scaled:center')
+    attr(train_x, 'scaled:scale') <- attr(train_x_mat, 'scaled:scale')
     col_means_train <- attr(train_x, "scaled:center") 
     col_stddevs_train <- attr(train_x, "scaled:scale")
     train_y <- train$rt
     
     validation_x <- validation %>%
       dplyr::select(-rt, -stock, -time)
-    validation_x <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x_mat <- scale(validation_x, center = col_means_train, scale = col_stddevs_train)
+    validation_x <- as.data.frame(validation_x_mat)
+    attr(validation_x, 'scaled:center') <- attr(validation_x_mat, 'scaled:center')
+    attr(validation_x, 'scaled:scale') <- attr(validation_x_mat, 'scaled:scale')
     validation_y <- validation$rt
       
     test_x <- test %>%
       dplyr::select(-rt, -stock, -time)
-    test_x <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x_mat <- scale(test_x, center = col_means_train, scale = col_stddevs_train)
+    test_x <- as.data.frame(test_x_mat)
+    attr(test_x, 'scaled:center') <- attr(test_x_mat, 'scaled:center')
+    attr(test_x, 'scaled:scale') <- attr(test_x_mat, 'scaled:scale')
     test_y <- test$rt
     
     pooled_panel_trunc <- rbind(


### PR DESCRIPTION
In R, scale() converts data frames to matrices and adds scaled:center and scaled:scale attributes. If converted back to a data frame (implicitly or explicitly), these attributes are stripped, leading to silent attribute loss. This fix preserves these attributes explicitly.

---
*PR created automatically by Jules for task [13508974025373530788](https://jules.google.com/task/13508974025373530788) started by @zeyuz35*