### PR TITLE
📝 Docent: replace cat with message for progress indicators

### DIFF
--- a/.jules/docent.md
+++ b/.jules/docent.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Replacing `cat()` with `message()` in progress bars
+**Learning:** `cat()` is often used to display progress bars (dots and newlines) when training neural networks in R using keras. The project's style standards dictate replacing `cat()` used for progress with `message()`.
+**Action:** Replace `cat("\n")` with `message("")` and `cat(".")` with `message(".", appendLF = FALSE)` inside the R code.

--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -1116,8 +1116,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/empirical_robustness/ff_factors/Real Data.Rmd
+++ b/R/empirical_robustness/ff_factors/Real Data.Rmd
@@ -1167,8 +1167,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/empirical_robustness/missing_threshold/Real Data.Rmd
+++ b/R/empirical_robustness/missing_threshold/Real Data.Rmd
@@ -1117,8 +1117,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/empirical_robustness/train_valid_1/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_1/Real Data.Rmd
@@ -1112,8 +1112,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/empirical_robustness/train_valid_2/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_2/Real Data.Rmd
@@ -1119,8 +1119,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -989,8 +989,8 @@ NNet_fit_stats <- function(pooled_panel, timeSlices, hidden_layers, loss_functio
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     
@@ -1438,8 +1438,8 @@ LSTM_fit_stats <- function(pooled_panel, timeSlices, loss_function, batch_size, 
     
     print_dot_callback <- callback_lambda(
       on_epoch_end = function(epoch, logs) {
-        if (epoch %% 50 == 0) cat("\n")
-        cat(".")
+        if (epoch %% 50 == 0) message("")
+        message(".", appendLF = FALSE)
       }
     ) 
     


### PR DESCRIPTION
Replaced raw `cat()` output used for progress bars with proper `message()` logging per agents.md guidelines.

---
*PR created automatically by Jules for task [16801120535851401398](https://jules.google.com/task/16801120535851401398) started by @zeyuz35*