### PR TITLE
🛡️ Sentinel: Fix hardcoded RStudio passwords in CloudFormation templates

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-21 - Remove Hardcoded RStudio Passwords
+**Vulnerability:** Hardcoded `rstudio` passwords and `passwd --stdin` usage found in CloudFormation templates (`R/AWS/sagemaker_stack.txt`, `R/AWS/template1`).
+**Learning:** Hardcoding credentials in version control allows unauthorized access to spun-up RStudio servers.
+**Prevention:** Always use CloudFormation parameters with `NoEcho: true` for sensitive inputs, and prefer `chpasswd` over `passwd --stdin` for better compatibility.

--- a/R/AWS/sagemaker_stack.txt
+++ b/R/AWS/sagemaker_stack.txt
@@ -2,6 +2,11 @@ Parameters:
   KeyName:
     Description: SSH key pair to use for instance login
     Type: AWS::EC2::KeyPair::KeyName
+  RStudioPassword:
+    Description: Password for the RStudio server web interface
+    Type: String
+    NoEcho: true
+    MinLength: 8
 
 Mappings:
   Region:
@@ -93,8 +98,8 @@ Resources:
           sudo apt install r-base
           sudo pip install sagemaker boto3
           sudo R -e "install.packages(c('reticulate', 'curl', 'tidyverse'), repos = 'http://cran.rstudio.com')"
-          sudo adduser rstudio
-          sudo sh -c "echo rstudio | passwd rstudio --stdin"
+          sudo useradd -m rstudio
+          sudo sh -c "echo 'rstudio:${RStudioPassword}' | chpasswd"
           wget https://download2.rstudio.org/rstudio-server-rhel-1.2.5033-x86_64.rpm
           sudo apt install -y rstudio-server-rhel-1.2.5033-x86_64.rpm
           sudo -u rstudio mkdir /home/rstudio/.aws

--- a/R/AWS/template1
+++ b/R/AWS/template1
@@ -2,6 +2,11 @@ Parameters:
   KeyName:
     Description: SSH key pair to use for instance login
     Type: AWS::EC2::KeyPair::KeyName
+  RStudioPassword:
+    Description: Password for the RStudio server web interface
+    Type: String
+    NoEcho: true
+    MinLength: 8
 
 Mappings:
   Region:
@@ -94,8 +99,8 @@ Resources:
           sudo ln -s /opt/R/3.6.2/bin/Rscript /usr/local/bin/Rscript
           sudo pip install sagemaker boto3
           sudo R -e "install.packages(c('reticulate', 'readr', 'curl', 'ggplot2', 'dplyr', 'stringr'), repos = 'http://cran.rstudio.com')"
-          sudo adduser rstudio
-          sudo sh -c "echo rstudio | passwd rstudio --stdin"
+          sudo useradd -m rstudio
+          sudo sh -c "echo 'rstudio:${RStudioPassword}' | chpasswd"
           wget https://download2.rstudio.org/rstudio-server-rhel-1.1.456-x86_64.rpm
           sudo yum install -y rstudio-server-rhel-1.1.456-x86_64.rpm
           sudo -u rstudio mkdir /home/rstudio/.aws


### PR DESCRIPTION
Removes hardcoded RStudio passwords from CloudFormation user data and introduces an `RStudioPassword` parameter with `NoEcho: true`. Also upgrades `adduser` and `passwd --stdin` to `useradd -m` and `chpasswd` for cross-platform compatibility.

---
*PR created automatically by Jules for task [6177510550732833704](https://jules.google.com/task/6177510550732833704) started by @zeyuz35*