### PR TITLE
⚡ Bolt: Vectorize array slice assignment

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-15 - Vectorize Array Slice Assignments
+**Learning:** Manual loops iterating over an array dimension are slow in R.
+**Action:** Use direct native vectorized slice assignments (e.g., `X[, 1, index] <- 0`) for better performance.

--- a/R/simulation/Simulation Models.Rmd
+++ b/R/simulation/Simulation Models.Rmd
@@ -1331,9 +1331,8 @@ LSTM_variable_importance <- function(X_array_test, Y_array_test, test_x, lstm_mo
     index <- seq(1, 200, by = 1) + (i - 1)*200
     
     X_array_test_zero <- X_array_test
-    for (t in 1:dim(X_array_test)[1]) {
-      X_array_test_zero[t, 1, index] <- 0
-    }
+    # ⚡ Bolt: Vectorized array slice assignment avoids the slow for loop over dim(X_array_test)[1], improving execution speed
+    X_array_test_zero[, 1, index] <- 0
 
     original_R2 <- R2(predict(lstm_model, X_array_test), Y_array_test %>% as.vector(), form = "traditional")
 


### PR DESCRIPTION
Replaces a manual for-loop over array dimensions with a native vectorized slice assignment to improve execution speed in LSTM_variable_importance.

---
*PR created automatically by Jules for task [10444028817694874920](https://jules.google.com/task/10444028817694874920) started by @zeyuz35*