### PR TITLE
🗃️ Curator: Preserve scale attributes when creating dataframe with cbind

### DIFF
--- a/.jules/curator.md
+++ b/.jules/curator.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Preserving scaled attributes after cbind()
+**Learning:** In R, applying `scale()` to a data.frame returns a matrix with attributes like `scaled:center` and `scaled:scale`. However, using `cbind()` to combine this matrix back into a data.frame silently drops these attributes in the resulting data.frame. This loses important scaling information.
+**Action:** When using `cbind()` with a scaled matrix to create a dataframe, extract the attributes first and explicitly assign them back to the resulting data.frame to preserve metadata correctly.

--- a/R/empirical/Real Data.Rmd
+++ b/R/empirical/Real Data.Rmd
@@ -329,7 +329,10 @@ cross_section_normalize <- function(dataset) {
     
     colnames(dataset_cross_section_x_norm) <- colnames(dataset_cross_section_x)
     
-    cbind(dataset_cross_section_y, dataset_cross_section_x_norm)
+    out <- cbind(dataset_cross_section_y, as.data.frame(dataset_cross_section_x_norm))
+    attr(out, "scaled:scale") <- attr(dataset_cross_section_x_norm, "scaled:scale")
+    attr(out, "scaled:center") <- attr(dataset_cross_section_x_norm, "scaled:center")
+    out
   }
   normalize_cross_section_df
 }

--- a/R/empirical_robustness/ff_factors/Real Data.Rmd
+++ b/R/empirical_robustness/ff_factors/Real Data.Rmd
@@ -335,7 +335,10 @@ cross_section_normalize <- function(dataset) {
     
     colnames(dataset_cross_section_x_norm) <- colnames(dataset_cross_section_x)
     
-    cbind(dataset_cross_section_y, dataset_cross_section_x_norm)
+    out <- cbind(dataset_cross_section_y, as.data.frame(dataset_cross_section_x_norm))
+    attr(out, "scaled:scale") <- attr(dataset_cross_section_x_norm, "scaled:scale")
+    attr(out, "scaled:center") <- attr(dataset_cross_section_x_norm, "scaled:center")
+    out
   }
   normalize_cross_section_df
 }

--- a/R/empirical_robustness/missing_threshold/Real Data.Rmd
+++ b/R/empirical_robustness/missing_threshold/Real Data.Rmd
@@ -328,7 +328,10 @@ cross_section_normalize <- function(dataset) {
     
     colnames(dataset_cross_section_x_norm) <- colnames(dataset_cross_section_x)
     
-    cbind(dataset_cross_section_y, dataset_cross_section_x_norm)
+    out <- cbind(dataset_cross_section_y, as.data.frame(dataset_cross_section_x_norm))
+    attr(out, "scaled:scale") <- attr(dataset_cross_section_x_norm, "scaled:scale")
+    attr(out, "scaled:center") <- attr(dataset_cross_section_x_norm, "scaled:center")
+    out
   }
   normalize_cross_section_df
 }

--- a/R/empirical_robustness/train_valid_1/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_1/Real Data.Rmd
@@ -326,7 +326,10 @@ cross_section_normalize <- function(dataset) {
     
     colnames(dataset_cross_section_x_norm) <- colnames(dataset_cross_section_x)
     
-    cbind(dataset_cross_section_y, dataset_cross_section_x_norm)
+    out <- cbind(dataset_cross_section_y, as.data.frame(dataset_cross_section_x_norm))
+    attr(out, "scaled:scale") <- attr(dataset_cross_section_x_norm, "scaled:scale")
+    attr(out, "scaled:center") <- attr(dataset_cross_section_x_norm, "scaled:center")
+    out
   }
   normalize_cross_section_df
 }

--- a/R/empirical_robustness/train_valid_2/Real Data.Rmd
+++ b/R/empirical_robustness/train_valid_2/Real Data.Rmd
@@ -328,7 +328,10 @@ cross_section_normalize <- function(dataset) {
     
     colnames(dataset_cross_section_x_norm) <- colnames(dataset_cross_section_x)
     
-    cbind(dataset_cross_section_y, dataset_cross_section_x_norm)
+    out <- cbind(dataset_cross_section_y, as.data.frame(dataset_cross_section_x_norm))
+    attr(out, "scaled:scale") <- attr(dataset_cross_section_x_norm, "scaled:scale")
+    attr(out, "scaled:center") <- attr(dataset_cross_section_x_norm, "scaled:center")
+    out
   }
   normalize_cross_section_df
 }


### PR DESCRIPTION
Fixes an issue where `scale` attributes are dropped when combining a scaled matrix back into a dataframe using `cbind()`. This explicitly captures and reapplies the attributes, avoiding silent data loss.

---
*PR created automatically by Jules for task [16163982716240826663](https://jules.google.com/task/16163982716240826663) started by @zeyuz35*